### PR TITLE
Refactor collections_config for dev/production network.

### DIFF
--- a/chaincode/collections_config_dev.json
+++ b/chaincode/collections_config_dev.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "TestCollection",
-    "policy": "OR('org1MSP.member','org2MSP.member')",
+    "policy": "OR('SampleOrgMSP.member')",
     "requiredPeerCount": 0,
     "maxPeerCount": 3,
     "blockToLive": 0,


### PR DESCRIPTION
### Reason for this PR
- a collections_config should only contain MSPs of existing organizations

### Changes in this PR
- Add collections_config for dev network.
- Remove non-existing msp from production collections_config.
