### PR TITLE
Fix tests not throwing error when querying for empty string

### DIFF
--- a/chaincode/src/test/java/de/upb/cs/uc4/chaincode/MatriculationDataChaincodeTest.java
+++ b/chaincode/src/test/java/de/upb/cs/uc4/chaincode/MatriculationDataChaincodeTest.java
@@ -113,8 +113,8 @@ public final class MatriculationDataChaincodeTest {
             Context ctx = mock(Context.class);
             ChaincodeStub stub = mock(ChaincodeStub.class);
             when(ctx.getStub()).thenReturn(stub);
-            when(stub.getStringState(null)).thenThrow(new RuntimeException());
-            when(stub.getStringState("")).thenThrow(new RuntimeException());
+            when(stub.getPrivateDataUTF8(contract.getCollectionName(),null)).thenThrow(new RuntimeException());
+            when(stub.getPrivateDataUTF8(contract.getCollectionName(),"")).thenThrow(new RuntimeException());
             if (!setup.isEmpty())
                 when(stub.getPrivateDataUTF8(contract.getCollectionName(), setup.get(0).getContent()))
                         .thenReturn(setup.get(1).getContent());
@@ -167,8 +167,8 @@ public final class MatriculationDataChaincodeTest {
             Context ctx = mock(Context.class);
             ChaincodeStub stub = mock(ChaincodeStub.class);
             when(ctx.getStub()).thenReturn(stub);
-            when(stub.getStringState(null)).thenThrow(new RuntimeException());
-            when(stub.getStringState("")).thenThrow(new RuntimeException());
+            when(stub.getPrivateDataUTF8(contract.getCollectionName(),null)).thenThrow(new RuntimeException());
+            when(stub.getPrivateDataUTF8(contract.getCollectionName(),"")).thenThrow(new RuntimeException());
             if (!setup.isEmpty()) {
                 when(stub.getPrivateDataUTF8(contract.getCollectionName(), setup.get(0).getContent()))
                         .thenReturn(setup.get(1).getContent());
@@ -270,8 +270,8 @@ public final class MatriculationDataChaincodeTest {
             Context ctx = mock(Context.class);
             ChaincodeStub stub = mock(ChaincodeStub.class);
             when(ctx.getStub()).thenReturn(stub);
-            when(stub.getStringState(null)).thenThrow(new RuntimeException());
-            when(stub.getStringState("")).thenThrow(new RuntimeException());
+            when(stub.getPrivateDataUTF8(contract.getCollectionName(), null)).thenThrow(new RuntimeException());
+            when(stub.getPrivateDataUTF8(contract.getCollectionName(),"")).thenThrow(new RuntimeException());
             if (!setup.isEmpty()) {
                 when(stub.getPrivateDataUTF8(contract.getCollectionName(), setup.get(0).getContent()))
                         .thenReturn(setup.get(1).getContent());

--- a/chaincode/src/test/resources/test_configs/AddEntryToMatriculationDataTestIO.json
+++ b/chaincode/src/test/resources/test_configs/AddEntryToMatriculationDataTestIO.json
@@ -577,6 +577,30 @@
   },
 
 
+  {
+    "name": "addEmptyMatriculationIdEntryToMatriculationData",
+    "type": "addEntryToMatriculationData_FAILURE",
+    "setup": [],
+    "input": [
+      "",
+      [
+        {
+          "fieldOfStudy": "Computer Science",
+          "semesters": [
+            "WS2018/19"
+          ]
+        }
+      ]
+    ],
+    "compare": [
+      {
+        "type": "HLNotFound",
+        "title": "There is no MatriculationData for the given matriculationId"
+      }
+    ]
+  },
+
+
 
   {
     "name": "addEntryToUnprocessableMatriculationData",


### PR DESCRIPTION
### Reason for this PR
- ```getPrivateDataUTF8``` throws an exception when queried for the empty string and should thus behave the same way in tests

### Changes in this PR
- change tests to throw a runtime exception when querying ```getPrivateDataUTF8``` for an empty string
- add test for adding a matriculation entry without specifying a matriculationId
