### PR TITLE
Add prefix to enrollmentId for storage on chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [v1.0.2](https://github.com/upb-uc4/hyperledger_chaincode/compare/v1.0.1...v1.0.2) (2020-10-01)
+
+## Bug Fixes
+- fix MatriculationDataContract and CertificateContract storing data under the same key (i.e. enrollmentId)
+
+## Refactor
+- refactor tests to do common setup only once per contract
+
+
+
 # [v1.0.1](https://github.com/upb-uc4/hyperledger_chaincode/compare/v1.0.0...v1.0.1) (2020-09-29)
 
 ## Feature

--- a/chaincode/src/main/java/de/upb/cs/uc4/chaincode/CertificateChaincode.java
+++ b/chaincode/src/main/java/de/upb/cs/uc4/chaincode/CertificateChaincode.java
@@ -45,7 +45,7 @@ public class CertificateChaincode implements ContractInterface {
             return GsonWrapper.toJson(cUtil.getUnprocessableEntityError(invalidParams));
         }
 
-        String result = stub.getStringState(enrollmentId);
+        String result = cUtil.getStringState(stub, enrollmentId);
         if (result != null && !result.equals("")) {
             return GsonWrapper.toJson(cUtil.getConflictError());
         }
@@ -73,7 +73,7 @@ public class CertificateChaincode implements ContractInterface {
             return GsonWrapper.toJson(cUtil.getUnprocessableEntityError(invalidParams));
         }
 
-        String certificateOnLedger = stub.getStringState(enrollmentId);
+        String certificateOnLedger = cUtil.getStringState(stub, enrollmentId);
 
         if (certificateOnLedger == null || certificateOnLedger.equals("")) {
             return GsonWrapper.toJson(cUtil.getNotFoundError());
@@ -98,7 +98,7 @@ public class CertificateChaincode implements ContractInterface {
             return GsonWrapper.toJson(cUtil.getUnprocessableEntityError(invalidParams));
         }
 
-        String certificate = stub.getStringState(enrollmentId);
+        String certificate = cUtil.getStringState(stub, enrollmentId);
 
         if (certificate == null || certificate.equals("")) {
             return GsonWrapper.toJson(cUtil.getNotFoundError());

--- a/chaincode/src/main/java/de/upb/cs/uc4/chaincode/MatriculationDataChaincode.java
+++ b/chaincode/src/main/java/de/upb/cs/uc4/chaincode/MatriculationDataChaincode.java
@@ -61,7 +61,7 @@ public class MatriculationDataChaincode implements ContractInterface {
             return GsonWrapper.toJson(cUtil.getUnprocessableEntityError(invalidParams));
         }
 
-        String result = stub.getStringState(matriculationData.getEnrollmentId());
+        String result = cUtil.getStringState(stub, matriculationData.getEnrollmentId());
         if (result != null && !result.equals("")) {
             return GsonWrapper.toJson(cUtil.getConflictError());
         }
@@ -99,7 +99,7 @@ public class MatriculationDataChaincode implements ContractInterface {
             return GsonWrapper.toJson(cUtil.getUnprocessableEntityError(invalidParams));
         }
 
-        String MatriculationDataOnLedger = stub.getStringState(matriculationData.getEnrollmentId());
+        String MatriculationDataOnLedger = cUtil.getStringState(stub, matriculationData.getEnrollmentId());
 
         if (MatriculationDataOnLedger == null || MatriculationDataOnLedger.equals("")) {
             return GsonWrapper.toJson(cUtil.getNotFoundError());
@@ -121,7 +121,7 @@ public class MatriculationDataChaincode implements ContractInterface {
         MatriculationData matriculationData;
 
         try {
-            matriculationData = GsonWrapper.fromJson(stub.getStringState(enrollmentId), MatriculationData.class);
+            matriculationData = GsonWrapper.fromJson(cUtil.getStringState(stub, enrollmentId), MatriculationData.class);
         } catch(Exception e) {
             return GsonWrapper.toJson(cUtil.getUnprocessableLedgerStateError());
         }
@@ -150,7 +150,7 @@ public class MatriculationDataChaincode implements ContractInterface {
         // retrieve jsonMatriculationData
         String jsonMatriculationData;
         try {
-            jsonMatriculationData = stub.getStringState(enrollmentId);
+            jsonMatriculationData = cUtil.getStringState(stub, enrollmentId);
         } catch(Exception e) {
             return GsonWrapper.toJson(cUtil.getNotFoundError());
         }

--- a/chaincode/src/main/java/de/upb/cs/uc4/chaincode/util/CertificateContractUtil.java
+++ b/chaincode/src/main/java/de/upb/cs/uc4/chaincode/util/CertificateContractUtil.java
@@ -4,8 +4,11 @@ import de.upb.cs.uc4.chaincode.model.GenericError;
 import de.upb.cs.uc4.chaincode.model.InvalidParameter;
 
 public class CertificateContractUtil extends ContractUtil {
-
     private final String thing = "certificate";
+
+    public CertificateContractUtil() {
+        keyPrefix = "certificate:";
+    }
 
     @Override
     public GenericError getConflictError() {

--- a/chaincode/src/main/java/de/upb/cs/uc4/chaincode/util/ContractUtil.java
+++ b/chaincode/src/main/java/de/upb/cs/uc4/chaincode/util/ContractUtil.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 
 abstract public class ContractUtil {
 
+    protected String keyPrefix = "";
+
     public DetailedError getUnprocessableEntityError(ArrayList<InvalidParameter> invalidParams) {
         return new DetailedError()
                 .type("HLUnprocessableEntity")
@@ -45,7 +47,15 @@ abstract public class ContractUtil {
     }
 
     public String putAndGetStringState(ChaincodeStub stub, String key, String value) {
-        stub.putStringState(key,value);
+        stub.putStringState(keyPrefix + key,value);
         return value;
+    }
+
+    public String getStringState(ChaincodeStub stub, String key) {
+        return stub.getStringState(keyPrefix + key);
+    }
+
+    public String getKeyPrefix() {
+        return keyPrefix;
     }
 }

--- a/chaincode/src/main/java/de/upb/cs/uc4/chaincode/util/MatriculationDataContractUtil.java
+++ b/chaincode/src/main/java/de/upb/cs/uc4/chaincode/util/MatriculationDataContractUtil.java
@@ -3,8 +3,11 @@ package de.upb.cs.uc4.chaincode.util;
 import de.upb.cs.uc4.chaincode.model.GenericError;
 
 public class MatriculationDataContractUtil extends ContractUtil {
-
     private final String thing = "MatriculationData";
+
+    public MatriculationDataContractUtil() {
+        keyPrefix = "matriculationData:";
+    }
 
     @Override
     public GenericError getConflictError() {

--- a/chaincode/src/test/java/de/upb/cs/uc4/chaincode/CertificateChaincodeTest.java
+++ b/chaincode/src/test/java/de/upb/cs/uc4/chaincode/CertificateChaincodeTest.java
@@ -3,6 +3,7 @@ package de.upb.cs.uc4.chaincode;
 
 import com.google.gson.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.model.JsonIOTest;
+import de.upb.cs.uc4.chaincode.util.CertificateContractUtil;
 import de.upb.cs.uc4.chaincode.util.GsonWrapper;
 import de.upb.cs.uc4.chaincode.util.TestUtil;
 import org.hyperledger.fabric.contract.Context;
@@ -20,6 +21,9 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public final class  CertificateChaincodeTest {
+
+    private final CertificateChaincode contract = new CertificateChaincode();
+    private final CertificateContractUtil cUtil = new CertificateContractUtil();
 
     @TestFactory
     List<DynamicTest> createTests() {
@@ -86,14 +90,13 @@ public final class  CertificateChaincodeTest {
         return tests;
     }
 
-    static Executable getCertificateTest(
+    private Executable getCertificateTest(
             List<String> setup,
             List<String> input,
             List<String> compare
     ) {
         return () -> {
-            CertificateChaincode contract = new CertificateChaincode();
-            Context ctx = TestUtil.mockContext(setup);
+            Context ctx = TestUtil.mockContext(setup, cUtil.getKeyPrefix());
 
             String certificate = contract.getCertificate(ctx, input.get(0));
             assertThat(certificate).isEqualTo(compare.get(0));
@@ -106,12 +109,11 @@ public final class  CertificateChaincodeTest {
             List<String> compare
     ) {
         return () -> {
-            CertificateChaincode contract = new CertificateChaincode();
-            Context ctx = TestUtil.mockContext(setup);
+            Context ctx = TestUtil.mockContext(setup, cUtil.getKeyPrefix());
 
             assertThat(contract.addCertificate(ctx, input.get(0), input.get(1)))
                     .isEqualTo(compare.get(0));
-            assertThat(ctx.getStub().getStringState(input.get(0)))
+            assertThat(ctx.getStub().getStringState(cUtil.getKeyPrefix() + input.get(0)))
                     .isEqualTo(compare.get(0));
         };
     }
@@ -122,8 +124,7 @@ public final class  CertificateChaincodeTest {
             List<String> compare
     ) {
         return () -> {
-            CertificateChaincode contract = new CertificateChaincode();
-            Context ctx = TestUtil.mockContext(setup);
+            Context ctx = TestUtil.mockContext(setup, cUtil.getKeyPrefix());
 
             String result = contract.addCertificate(ctx, input.get(0), input.get(1));
             assertThat(result).isEqualTo(compare.get(0));
@@ -136,12 +137,11 @@ public final class  CertificateChaincodeTest {
             List<String> compare
     ) {
         return () -> {
-            CertificateChaincode contract = new CertificateChaincode();
-            Context ctx = TestUtil.mockContext(setup);
+            Context ctx = TestUtil.mockContext(setup, cUtil.getKeyPrefix());
 
             assertThat(contract.updateCertificate(ctx, input.get(0), input.get(1)))
                     .isEqualTo(compare.get(0));
-            assertThat(ctx.getStub().getStringState(input.get(0)))
+            assertThat(ctx.getStub().getStringState(cUtil.getKeyPrefix() + input.get(0)))
                     .isEqualTo(compare.get(0));
         };
 
@@ -153,8 +153,7 @@ public final class  CertificateChaincodeTest {
             List<String> compare
     ) {
         return () -> {
-            CertificateChaincode contract = new CertificateChaincode();
-            Context ctx = TestUtil.mockContext(setup);
+            Context ctx = TestUtil.mockContext(setup, cUtil.getKeyPrefix());
 
             String result = contract.updateCertificate(ctx, input.get(0), input.get(1));
             assertThat(result).isEqualTo(compare.get(0));

--- a/chaincode/src/test/java/de/upb/cs/uc4/chaincode/MatriculationDataChaincodeTest.java
+++ b/chaincode/src/test/java/de/upb/cs/uc4/chaincode/MatriculationDataChaincodeTest.java
@@ -5,6 +5,7 @@ import com.google.gson.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.model.JsonIOTest;
 import de.upb.cs.uc4.chaincode.model.MatriculationData;
 import de.upb.cs.uc4.chaincode.util.GsonWrapper;
+import de.upb.cs.uc4.chaincode.util.MatriculationDataContractUtil;
 import de.upb.cs.uc4.chaincode.util.TestUtil;
 import org.hyperledger.fabric.contract.Context;
 import org.junit.jupiter.api.DynamicTest;
@@ -20,6 +21,9 @@ import java.util.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public final class MatriculationDataChaincodeTest {
+
+    private final MatriculationDataChaincode contract = new MatriculationDataChaincode();
+    private final MatriculationDataContractUtil cUtil = new MatriculationDataContractUtil();
 
     @TestFactory
     List<DynamicTest> createTests() {
@@ -98,14 +102,13 @@ public final class MatriculationDataChaincodeTest {
         return tests;
     }
 
-    static Executable getMatriculationDataTest(
+    private Executable getMatriculationDataTest(
             List<String> setup,
             List<String> input,
             List<String> compare
     ) {
         return () -> {
-            MatriculationDataChaincode contract = new MatriculationDataChaincode();
-            Context ctx = TestUtil.mockContext(setup);
+            Context ctx = TestUtil.mockContext(setup, cUtil.getKeyPrefix());
 
             MatriculationData matriculationData = GsonWrapper.fromJson(
                     contract.getMatriculationData(ctx, input.get(0)),
@@ -121,13 +124,12 @@ public final class MatriculationDataChaincodeTest {
             List<String> compare
     ) {
         return () -> {
-            MatriculationDataChaincode contract = new MatriculationDataChaincode();
-            Context ctx = TestUtil.mockContext(setup);
+            Context ctx = TestUtil.mockContext(setup, cUtil.getKeyPrefix());
 
             assertThat(contract.addMatriculationData(ctx, input.get(0)))
                     .isEqualTo(compare.get(0));
             MatriculationData matriculationData = GsonWrapper.fromJson(compare.get(0), MatriculationData.class);
-            assertThat(ctx.getStub().getStringState(matriculationData.getEnrollmentId()))
+            assertThat(ctx.getStub().getStringState(cUtil.getKeyPrefix() + matriculationData.getEnrollmentId()))
                     .isEqualTo(compare.get(0));
         };
     }
@@ -138,8 +140,7 @@ public final class MatriculationDataChaincodeTest {
             List<String> compare
     ) {
         return () -> {
-            MatriculationDataChaincode contract = new MatriculationDataChaincode();
-            Context ctx = TestUtil.mockContext(setup);
+            Context ctx = TestUtil.mockContext(setup, cUtil.getKeyPrefix());
 
             String result = contract.addMatriculationData(ctx, input.get(0));
             assertThat(result).isEqualTo(compare.get(0));
@@ -152,13 +153,12 @@ public final class MatriculationDataChaincodeTest {
             List<String> compare
     ) {
         return () -> {
-            MatriculationDataChaincode contract = new MatriculationDataChaincode();
-            Context ctx = TestUtil.mockContext(setup);
+            Context ctx = TestUtil.mockContext(setup, cUtil.getKeyPrefix());
 
             assertThat(contract.updateMatriculationData(ctx, input.get(0)))
                     .isEqualTo(compare.get(0));
             MatriculationData matriculationData = GsonWrapper.fromJson(compare.get(0), MatriculationData.class);
-            assertThat(ctx.getStub().getStringState(matriculationData.getEnrollmentId()))
+            assertThat(ctx.getStub().getStringState(cUtil.getKeyPrefix() + matriculationData.getEnrollmentId()))
                     .isEqualTo(compare.get(0));
         };
 
@@ -170,8 +170,7 @@ public final class MatriculationDataChaincodeTest {
             List<String> compare
     ) {
         return () -> {
-            MatriculationDataChaincode contract = new MatriculationDataChaincode();
-            Context ctx = TestUtil.mockContext(setup);
+            Context ctx = TestUtil.mockContext(setup, cUtil.getKeyPrefix());
 
             String result = contract.updateMatriculationData(ctx, input.get(0));
             assertThat(result).isEqualTo(compare.get(0));
@@ -184,13 +183,12 @@ public final class MatriculationDataChaincodeTest {
             List<String> compare
     ) {
         return () -> {
-            MatriculationDataChaincode contract = new MatriculationDataChaincode();
-            Context ctx = TestUtil.mockContext(setup);
+            Context ctx = TestUtil.mockContext(setup, cUtil.getKeyPrefix());
 
             assertThat(contract.addEntriesToMatriculationData(ctx, input.get(0), input.get(1)))
                     .isEqualTo(compare.get(0));
             MatriculationData matriculationData = GsonWrapper.fromJson(compare.get(0), MatriculationData.class);
-            assertThat(ctx.getStub().getStringState(matriculationData.getEnrollmentId()))
+            assertThat(ctx.getStub().getStringState(cUtil.getKeyPrefix() + matriculationData.getEnrollmentId()))
                     .isEqualTo(compare.get(0));
         };
     }
@@ -201,8 +199,7 @@ public final class MatriculationDataChaincodeTest {
             List<String> compare
     ) {
         return () -> {
-            MatriculationDataChaincode contract = new MatriculationDataChaincode();
-            Context ctx = TestUtil.mockContext(setup);
+            Context ctx = TestUtil.mockContext(setup, cUtil.getKeyPrefix());
 
             String result = contract.addEntriesToMatriculationData(ctx, input.get(0), input.get(1));
             assertThat(result).isEqualTo(compare.get(0));

--- a/chaincode/src/test/java/de/upb/cs/uc4/chaincode/util/TestUtil.java
+++ b/chaincode/src/test/java/de/upb/cs/uc4/chaincode/util/TestUtil.java
@@ -16,15 +16,19 @@ public class TestUtil {
     }
 
     public static Context mockContext(List<String> setup) {
+        return mockContext(setup, "");
+    }
+
+    public static Context mockContext(List<String> setup, String keyPrefix) {
         Context ctx = mock(Context.class);
-        when(ctx.getStub()).thenReturn(mockStub(setup));
+        when(ctx.getStub()).thenReturn(mockStub(setup, keyPrefix));
         return ctx;
     }
 
-    private static MockChaincodeStub mockStub(List<String> setup) {
+    private static MockChaincodeStub mockStub(List<String> setup, String keyPrefix) {
         MockChaincodeStub stub = new MockChaincodeStub();
         for (int i=0; i<setup.size(); i+=2) {
-            stub.putStringState(setup.get(i), setup.get(i+1));
+            stub.putStringState(keyPrefix + setup.get(i), setup.get(i+1));
         }
         return stub;
     }


### PR DESCRIPTION
### Reason for this PR
- storing different types of data under the same key seems not to be possible across different contracts

### Changes in this PR
- add prefixes for keys of different kinds of data being stored under the same key
