### PR TITLE
Refactor versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [v1.0.0](https://github.com/upb-uc4/hyperledger_chaincode/compare/v0.8.0...v1.0.0) (2020-09-28)
+# [v0.9.0](https://github.com/upb-uc4/hyperledger_chaincode/compare/v0.8.0...v0.9.0) (2020-09-28)
 
 ## Feature
 -


### PR DESCRIPTION
### Reason for this PR
- we do not start at v1.0.0 for the mvp :weary:

### Changes in this PR
- refactor versioning in changelog
