### PR TITLE
Update matriculation-contract transaction parameters to be consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# [v0.11.5](https://github.com/upb-uc4/hyperledger_chaincode/compare/v0.11.4...develop) (TBD)
+# [v0.11.5](https://github.com/upb-uc4/hyperledger_chaincode/compare/v0.11.4...v0.11.5) (2020-11-04)
 
 ## Refactor
+- rename ```Module``` model to ```ExaminationRegulationModule```
 - rename matriculation-contract transaction parameters to be consistent with the api
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [v0.11.5](https://github.com/upb-uc4/hyperledger_chaincode/compare/v0.11.4...develop) (TBD)
+
+## Refactor
+- rename matriculation-contract transaction parameters to be consistent with the api
+
+
+
 # [v0.11.4](https://github.com/upb-uc4/hyperledger_chaincode/compare/v0.11.3...v0.11.4) (2020-11-04)
 
 ## Feature

--- a/chaincode/src/main/java/de/upb/cs/uc4/chaincode/ContractBase.java
+++ b/chaincode/src/main/java/de/upb/cs/uc4/chaincode/ContractBase.java
@@ -7,7 +7,7 @@ import org.hyperledger.fabric.contract.annotation.Transaction;
 
 public abstract class ContractBase implements ContractInterface {
 
-    private final String version = "v0.11.4";
+    private final String version = "v0.11.5";
 
     /**
      * Gets version of the chaincode

--- a/chaincode/src/main/java/de/upb/cs/uc4/chaincode/ExaminationRegulationContract.java
+++ b/chaincode/src/main/java/de/upb/cs/uc4/chaincode/ExaminationRegulationContract.java
@@ -41,7 +41,7 @@ public class ExaminationRegulationContract extends ContractBase {
             return GsonWrapper.toJson(cUtil.getUnprocessableEntityError(cUtil.getUnparsableExaminationRegulationParam()));
         }
 
-        HashSet<Module> validModules = new HashSet<>();
+        HashSet<ExaminationRegulationModule> validModules = new HashSet<>();
         List<ExaminationRegulation> regulations;
         try {
             regulations = cUtil.getAllStates(stub);

--- a/chaincode/src/main/java/de/upb/cs/uc4/chaincode/MatriculationDataContract.java
+++ b/chaincode/src/main/java/de/upb/cs/uc4/chaincode/MatriculationDataContract.java
@@ -25,63 +25,63 @@ public class MatriculationDataContract extends ContractBase {
     /**
      * Adds MatriculationData to the ledger.
      * @param ctx transaction context providing access to ChaincodeStub etc.
-     * @param newMatriculationData MatriculationData to be added
+     * @param matriculationData MatriculationData to be added
      * @return newMatriculationData on success, serialized error on failure
      */
     @Transaction()
-    public String addMatriculationData(final Context ctx, String newMatriculationData) {
+    public String addMatriculationData(final Context ctx, String matriculationData) {
 
         ChaincodeStub stub = ctx.getStub();
 
-        MatriculationData matriculationData;
+        MatriculationData newMatriculationData;
         try {
-            matriculationData = GsonWrapper.fromJson(newMatriculationData, MatriculationData.class);
+            newMatriculationData = GsonWrapper.fromJson(matriculationData, MatriculationData.class);
         } catch(Exception e) {
             return GsonWrapper.toJson(cUtil.getUnprocessableEntityError(cUtil.getUnparsableMatriculationDataParam()));
         }
 
         ArrayList<InvalidParameter> invalidParams = cUtil.getErrorForMatriculationData(
-                matriculationData, "matriculationData");
+                newMatriculationData, "matriculationData");
         if (!invalidParams.isEmpty()) {
             return GsonWrapper.toJson(cUtil.getUnprocessableEntityError(invalidParams));
         }
 
-        if (cUtil.keyExists(stub, matriculationData.getEnrollmentId())) {
+        if (cUtil.keyExists(stub, newMatriculationData.getEnrollmentId())) {
             return GsonWrapper.toJson(cUtil.getConflictError());
         }
 
-        return cUtil.putAndGetStringState(stub, matriculationData.getEnrollmentId(), GsonWrapper.toJson(matriculationData));
+        return cUtil.putAndGetStringState(stub, newMatriculationData.getEnrollmentId(), GsonWrapper.toJson(newMatriculationData));
     }
 
     /**
      * Updates MatriculationData on the ledger.
      * @param ctx transaction context providing access to ChaincodeStub etc.
-     * @param updatedMatriculationData json-representation of the new MatriculationData to replace the old with
+     * @param matriculationData json-representation of the new MatriculationData to replace the old with
      * @return updatedMatriculationData on success, serialized error on failure
      */
     @Transaction()
-    public String updateMatriculationData(final Context ctx, String updatedMatriculationData) {
+    public String updateMatriculationData(final Context ctx, String matriculationData) {
 
         ChaincodeStub stub = ctx.getStub();
 
-        MatriculationData matriculationData;
+        MatriculationData newMatriculationData;
         try {
-            matriculationData = GsonWrapper.fromJson(updatedMatriculationData, MatriculationData.class);
+            newMatriculationData = GsonWrapper.fromJson(matriculationData, MatriculationData.class);
         } catch(Exception e) {
             return GsonWrapper.toJson(cUtil.getUnprocessableEntityError(cUtil.getUnparsableMatriculationDataParam()));
         }
 
         ArrayList<InvalidParameter> invalidParams = cUtil.getErrorForMatriculationData(
-                matriculationData, "matriculationData");
+                newMatriculationData, "matriculationData");
         if (!invalidParams.isEmpty()) {
             return GsonWrapper.toJson(cUtil.getUnprocessableEntityError(invalidParams));
         }
 
-        if (!cUtil.keyExists(stub, matriculationData.getEnrollmentId())) {
+        if (!cUtil.keyExists(stub, newMatriculationData.getEnrollmentId())) {
             return GsonWrapper.toJson(cUtil.getNotFoundError());
         }
 
-        return cUtil.putAndGetStringState(stub, matriculationData.getEnrollmentId(), GsonWrapper.toJson(matriculationData));
+        return cUtil.putAndGetStringState(stub, newMatriculationData.getEnrollmentId(), GsonWrapper.toJson(newMatriculationData));
     }
 
     /**

--- a/chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/ExaminationRegulation.java
+++ b/chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/ExaminationRegulation.java
@@ -16,7 +16,7 @@ public class ExaminationRegulation {
   private boolean active = true;
 
   @SerializedName("modules")
-  private List<Module> modules = null;
+  private List<ExaminationRegulationModule> modules = null;
 
   public ExaminationRegulation name(String name) {
     this.name = name;
@@ -46,25 +46,25 @@ public class ExaminationRegulation {
     this.active = active;
   }
 
-  public ExaminationRegulation modules(List<Module> modules) {
+  public ExaminationRegulation modules(List<ExaminationRegulationModule> modules) {
     this.modules = modules;
     return this;
   }
 
-  public ExaminationRegulation addModuleItem(Module module) {
+  public ExaminationRegulation addModuleItem(ExaminationRegulationModule module) {
     if (this.modules == null) {
-      this.modules = new ArrayList<Module>();
+      this.modules = new ArrayList<ExaminationRegulationModule>();
     }
     this.modules.add(module);
     return this;
   }
 
   @ApiModelProperty(value = "")
-  public List<Module> getModules() {
+  public List<ExaminationRegulationModule> getModules() {
     return modules;
   }
 
-  public void setModules(List<Module> modules) {
+  public void setModules(List<ExaminationRegulationModule> modules) {
     this.modules = modules;
   }
 
@@ -112,10 +112,10 @@ public class ExaminationRegulation {
     return o.toString().replace("\n", "\n    ");
   }
 
-  public void addAbsent(ArrayList<Module> modules) {
-    for (Module newItem: modules) {
+  public void addAbsent(ArrayList<ExaminationRegulationModule> modules) {
+    for (ExaminationRegulationModule newItem: modules) {
       boolean exists = false;
-      for (Module item : this.getModules()) {
+      for (ExaminationRegulationModule item : this.getModules()) {
         if (item.getId().equals(newItem.getId())) {
           this.getModules().add(newItem);
           break;

--- a/chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/ExaminationRegulationModule.java
+++ b/chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/ExaminationRegulationModule.java
@@ -3,12 +3,10 @@ package de.upb.cs.uc4.chaincode.model;
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModelProperty;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 
-public class Module {
+public class ExaminationRegulationModule {
 
   @SerializedName("id")
   private String id = null;
@@ -16,12 +14,12 @@ public class Module {
   @SerializedName("name")
   private String name = null;
 
-  public Module id(String id) {
+  public ExaminationRegulationModule id(String id) {
     this.id = id;
     return this;
   }
 
-  public Module name(String name) {
+  public ExaminationRegulationModule name(String name) {
     this.name = name;
     return this;
   }
@@ -55,7 +53,7 @@ public class Module {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    Module module = (Module) o;
+    ExaminationRegulationModule module = (ExaminationRegulationModule) o;
     return Objects.equals(this.id, module.id) &&
         Objects.equals(this.name, module.name);
   }

--- a/chaincode/src/main/java/de/upb/cs/uc4/chaincode/util/ExaminationRegulationContractUtil.java
+++ b/chaincode/src/main/java/de/upb/cs/uc4/chaincode/util/ExaminationRegulationContractUtil.java
@@ -107,7 +107,7 @@ public class ExaminationRegulationContractUtil extends ContractUtil {
         return examinationRegulations;
     }
 
-    public ArrayList<InvalidParameter> getErrorForExaminationRegulation(ExaminationRegulation examinationRegulation, Set<Module> validModules) {
+    public ArrayList<InvalidParameter> getErrorForExaminationRegulation(ExaminationRegulation examinationRegulation, Set<ExaminationRegulationModule> validModules) {
         ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
 
         if(valueUnset(examinationRegulation.getName())) {
@@ -121,7 +121,7 @@ public class ExaminationRegulationContractUtil extends ContractUtil {
         return invalidParams;
     }
 
-    public ArrayList<InvalidParameter> getErrorForModuleList(List<Module> modules, String prefix, Set<Module> validModules) {
+    public ArrayList<InvalidParameter> getErrorForModuleList(List<ExaminationRegulationModule> modules, String prefix, Set<ExaminationRegulationModule> validModules) {
         ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
 
         if (valueUnset(modules)) {
@@ -131,7 +131,7 @@ public class ExaminationRegulationContractUtil extends ContractUtil {
 
             for (int moduleIndex=0; moduleIndex<modules.size(); moduleIndex++) {
 
-                Module module = modules.get(moduleIndex);
+                ExaminationRegulationModule module = modules.get(moduleIndex);
 
                 if (valueUnset(module.getId())) {
                     invalidParams.add(getEmptyModuleIdParam(prefix + "[" + moduleIndex + "]."));
@@ -144,7 +144,7 @@ public class ExaminationRegulationContractUtil extends ContractUtil {
                 if (valueUnset(module.getName())) {
                     invalidParams.add(getEmptyModuleNameParam(prefix + "[" + moduleIndex + "]."));
                 }
-                for (Module validModule: validModules) {
+                for (ExaminationRegulationModule validModule: validModules) {
                     if (module.getId().equals(validModule.getId()) && !module.equals(validModule)) {
                         invalidParams.add(getInconsistentModuleParam(prefix + "[" + moduleIndex + "]"));
                         break;


### PR DESCRIPTION
### Reason for this PR
- naming scheme of matriculation contract should be consistent with the api

### Changes in this PR
- adjust parameter names to be consistent with the api
