### PR TITLE
remove constructor, instead "hide"(override) protected variable

### DIFF
--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/ContractBase.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/ContractBase.java
@@ -31,8 +31,4 @@ public abstract class ContractBase implements ContractInterface {
 
         return v1;*/
     }
-
-    public String getContractName() {
-        return contractName;
-    }
 }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/MatriculationDataContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/MatriculationDataContract.java
@@ -23,10 +23,7 @@ import java.util.List;
 public class MatriculationDataContract extends ContractBase {
     private final MatriculationDataContractUtil cUtil = new MatriculationDataContractUtil();
 
-    MatriculationDataContract() {
-        super();
-        this.contractName = "UC4.MatriculationData";
-    }
+    protected String contractName = "UC4.MatriculationData";
 
     /**
      * Adds MatriculationData to the ledger.
@@ -63,7 +60,7 @@ public class MatriculationDataContract extends ContractBase {
                 ctx,
                 requiredIds,
                 requiredTypes,
-                contractName,
+                getContractName(),
                 "addMatriculationData",
                 Collections.singletonList(matriculationData))) {
             return GsonWrapper.toJson(cUtil.getInsufficientApprovalsError());

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/MatriculationDataContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/MatriculationDataContract.java
@@ -60,7 +60,7 @@ public class MatriculationDataContract extends ContractBase {
                 ctx,
                 requiredIds,
                 requiredTypes,
-                getContractName(),
+                this.contractName,
                 "addMatriculationData",
                 Collections.singletonList(matriculationData))) {
             return GsonWrapper.toJson(cUtil.getInsufficientApprovalsError());

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/MatriculationDataContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/MatriculationDataContractTest.java
@@ -133,7 +133,7 @@ public final class MatriculationDataContractTest {
             ApprovalContract approvalContract = new ApprovalContract();
             for (Approval id: ids) {
                 Context ctx = TestUtil.mockContext(stub, id);
-                approvalContract.approveTransaction(ctx, contract.getContractName(),"addMatriculationData", input.get(0));
+                approvalContract.approveTransaction(ctx, contract.contractName,"addMatriculationData", input.get(0));
             }
             Context ctx = TestUtil.mockContext(stub);
             assertThat(contract.addMatriculationData(ctx, input.get(0)))


### PR DESCRIPTION
### Reason for this PR
- constructor breaks access via network

### Changes in this PR
- exchange constructor for direct overwrite (java.hide) of variable
