### PR TITLE
feature/operation_state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# [v0.15.2](https://github.com/upb-uc4/hyperledger_chaincode/compare/v0.15.1...v0.15.2) (2021-01-12)
+
+## Feature
+- set operation state to FINISHED on successful transaction execution
+
+## Bugfix
+- 
+
+## Refactor
+- read transactionId from stub
+- read annotated contract name from static contract name
+
+## Usability
+- 
+
 # [v0.15.1](https://github.com/upb-uc4/hyperledger_chaincode/compare/v0.15.0...v0.15.1) (2021-01-12)
 
 ## Feature

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/certificate/CertificateContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/certificate/CertificateContract.java
@@ -12,13 +12,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 @Contract(
-        name = "UC4.Certificate"
+        name = CertificateContract.contractName
 )
 public class CertificateContract extends ContractBase {
 
     private final CertificateContractUtil cUtil = new CertificateContractUtil();
 
-    public final String contractName = "UC4.Certificate";
+    public final static String contractName = "UC4.Certificate";
 
     /**
      * Adds a certificate to the ledger.
@@ -30,6 +30,7 @@ public class CertificateContract extends ContractBase {
      */
     @Transaction()
     public String addCertificate(final Context ctx, final String enrollmentId, final String certificate) {
+        String transactionName = ctx.getStub().getTxId().split(":")[1];
         try {
             cUtil.checkParamsAddCertificate(ctx, new ArrayList<String>(){{add(enrollmentId); add(certificate);}});
         } catch (ParameterError e) {
@@ -38,7 +39,12 @@ public class CertificateContract extends ContractBase {
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(stub, this.contractName,  "addCertificate", new ArrayList<String>(){{add(enrollmentId);add(certificate);}});
+            cUtil.validateApprovals(stub, this.contractName,  transactionName, new ArrayList<String>(){{add(enrollmentId);add(certificate);}});
+        } catch (SerializableError e) {
+            return e.getJsonError();
+        }
+        try {
+            cUtil.finishOperation(stub, this.contractName,  transactionName, new ArrayList<String>(){{add(enrollmentId);add(certificate);}});
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -55,6 +61,7 @@ public class CertificateContract extends ContractBase {
      */
     @Transaction()
     public String updateCertificate(final Context ctx, final String enrollmentId, final String certificate) {
+        String transactionName = ctx.getStub().getTxId().split(":")[1];
         try {
             cUtil.checkParamsUpdateCertificate(ctx, new ArrayList<String>(){{add(enrollmentId); add(certificate);}});
         } catch (ParameterError e) {
@@ -63,7 +70,12 @@ public class CertificateContract extends ContractBase {
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(stub, this.contractName,  "updateCertificate", new ArrayList<String>(){{add(enrollmentId);add(certificate);}});
+            cUtil.validateApprovals(stub, this.contractName,  transactionName, new ArrayList<String>(){{add(enrollmentId);add(certificate);}});
+        } catch (SerializableError e) {
+            return e.getJsonError();
+        }
+        try {
+            cUtil.finishOperation(stub, this.contractName,  transactionName, new ArrayList<String>(){{add(enrollmentId);add(certificate);}});
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -79,6 +91,7 @@ public class CertificateContract extends ContractBase {
      */
     @Transaction()
     public String getCertificate(final Context ctx, final String enrollmentId) {
+        String transactionName = ctx.getStub().getTxId().split(":")[1];
         try {
             cUtil.checkParamsGetCertificate(ctx, Collections.singletonList(enrollmentId));
         } catch (ParameterError e) {
@@ -87,11 +100,15 @@ public class CertificateContract extends ContractBase {
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(stub, this.contractName,  "getCertificate", Collections.singletonList(enrollmentId));
+            cUtil.validateApprovals(stub, this.contractName,  transactionName, Collections.singletonList(enrollmentId));
         } catch (SerializableError e) {
             return e.getJsonError();
         }
-        String certificate = cUtil.getStringState(stub, enrollmentId);
-        return certificate;
+        try {
+            cUtil.finishOperation(stub, this.contractName,  transactionName, Collections.singletonList(enrollmentId));
+        } catch (SerializableError e) {
+            return e.getJsonError();
+        }
+        return cUtil.getStringState(stub, enrollmentId);
     }
 }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examinationregulation/ExaminationRegulationContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examinationregulation/ExaminationRegulationContract.java
@@ -18,12 +18,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 @Contract(
-        name = "UC4.ExaminationRegulation"
+        name = ExaminationRegulationContract.contractName
 )
 public class ExaminationRegulationContract extends ContractBase {
 
     private final ExaminationRegulationContractUtil cUtil = new ExaminationRegulationContractUtil();
-    public final String contractName = "UC4.ExaminationRegulation";
+    public final static String contractName = "UC4.ExaminationRegulation";
 
     /**
      * Adds an examination regulation to the ledger.
@@ -34,6 +34,7 @@ public class ExaminationRegulationContract extends ContractBase {
      */
     @Transaction()
     public String addExaminationRegulation(final Context ctx, final String examinationRegulation) {
+        String transactionName = ctx.getStub().getTxId().split(":")[1];
         try {
             cUtil.checkParamsAddExaminationRegulation(ctx, Collections.singletonList(examinationRegulation));
         } catch (ParameterError e) {
@@ -42,11 +43,16 @@ public class ExaminationRegulationContract extends ContractBase {
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(stub, this.contractName,  "addExaminationRegulation", Collections.singletonList(examinationRegulation));
+            cUtil.validateApprovals(stub, this.contractName,  transactionName, Collections.singletonList(examinationRegulation));
         } catch (SerializableError e) {
             return e.getJsonError();
         }
         ExaminationRegulation newExaminationRegulation = GsonWrapper.fromJson(examinationRegulation, ExaminationRegulation.class);
+        try {
+            cUtil.finishOperation(stub, this.contractName,  transactionName, Collections.singletonList(examinationRegulation));
+        } catch (SerializableError e) {
+            return e.getJsonError();
+        }
         return cUtil.putAndGetStringState(stub, newExaminationRegulation.getName(), GsonWrapper.toJson(newExaminationRegulation));
     }
 
@@ -59,6 +65,7 @@ public class ExaminationRegulationContract extends ContractBase {
      */
     @Transaction()
     public String getExaminationRegulations(final Context ctx, final String names) {
+        String transactionName = ctx.getStub().getTxId().split(":")[1];
         try {
             cUtil.checkParamsGetExaminationRegulations(Collections.singletonList(names));
         } catch (ParameterError e) {
@@ -67,7 +74,7 @@ public class ExaminationRegulationContract extends ContractBase {
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(stub, this.contractName,  "getExaminationRegulations", Collections.singletonList(names));
+            cUtil.validateApprovals(stub, this.contractName,  transactionName, Collections.singletonList(names));
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -99,6 +106,11 @@ public class ExaminationRegulationContract extends ContractBase {
                 }
             }
         }
+        try {
+            cUtil.finishOperation(stub, this.contractName,  transactionName, Collections.singletonList(names));
+        } catch (SerializableError e) {
+            return e.getJsonError();
+        }
         return GsonWrapper.toJson(regulations);
     }
 
@@ -111,6 +123,7 @@ public class ExaminationRegulationContract extends ContractBase {
      */
     @Transaction()
     public String closeExaminationRegulation(final Context ctx, final String name) {
+        String transactionName = ctx.getStub().getTxId().split(":")[1];
         try {
             cUtil.checkParamsCloseExaminationRegulation(ctx, Collections.singletonList(name));
         } catch (SerializableError e) {
@@ -119,7 +132,7 @@ public class ExaminationRegulationContract extends ContractBase {
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(stub, this.contractName,  "closeExaminationRegulation", Collections.singletonList(name));
+            cUtil.validateApprovals(stub, this.contractName,  transactionName, Collections.singletonList(name));
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -131,6 +144,11 @@ public class ExaminationRegulationContract extends ContractBase {
         }
 
         regulation.setActive(false);
+        try {
+            cUtil.finishOperation(stub, this.contractName,  transactionName, Collections.singletonList(name));
+        } catch (SerializableError e) {
+            return e.getJsonError();
+        }
         return cUtil.putAndGetStringState(stub, regulation.getName(), GsonWrapper.toJson(regulation));
     }
 }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/group/GroupContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/group/GroupContract.java
@@ -4,12 +4,10 @@ import de.upb.cs.uc4.chaincode.contract.ContractBase;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.LedgerAccessError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.ParameterError;
 import de.upb.cs.uc4.chaincode.exceptions.SerializableError;
-import de.upb.cs.uc4.chaincode.helper.AccessManager;
 import de.upb.cs.uc4.chaincode.model.Group;
 import de.upb.cs.uc4.chaincode.helper.GsonWrapper;
 import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.contract.annotation.Contract;
-import org.hyperledger.fabric.contract.annotation.Default;
 import org.hyperledger.fabric.contract.annotation.Transaction;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 
@@ -18,13 +16,12 @@ import java.util.Collections;
 import java.util.List;
 
 @Contract(
-        name = "UC4.Group"
+        name = GroupContract.contractName
 )
-@Default
 public class GroupContract extends ContractBase {
     private final GroupContractUtil cUtil = new GroupContractUtil();
 
-    public String contractName = "UC4.Group";
+    public final static String contractName = "UC4.Group";
 
     /**
      * Adds user to group.
@@ -36,6 +33,7 @@ public class GroupContract extends ContractBase {
      */
     @Transaction()
     public String addUserToGroup(final Context ctx, String enrollmentId, String groupId) {
+        String transactionName = ctx.getStub().getTxId().split(":")[1];
         try {
             cUtil.checkParamsAddUserToGroup(ctx, new ArrayList<String>(){{add(enrollmentId); add(groupId);}});
         } catch (ParameterError e) {
@@ -56,13 +54,17 @@ public class GroupContract extends ContractBase {
         }
 
         try {
-            cUtil.validateApprovals(stub, this.contractName, "addUserToGroup", new ArrayList<String>() {{add(enrollmentId);add(groupId);}});
+            cUtil.validateApprovals(stub, this.contractName, transactionName, new ArrayList<String>() {{add(enrollmentId);add(groupId);}});
         } catch (SerializableError e) {
             return e.getJsonError();
         }
 
         cUtil.putAndGetStringState(stub, groupId, GsonWrapper.toJson(group));
-
+        try {
+            cUtil.finishOperation(stub, this.contractName, transactionName, new ArrayList<String>() {{add(enrollmentId);add(groupId);}});
+        } catch (SerializableError e) {
+            return e.getJsonError();
+        }
         return "";
     }
 
@@ -76,6 +78,7 @@ public class GroupContract extends ContractBase {
      */
     @Transaction()
     public String removeUserFromGroup(final Context ctx, String enrollmentId, String groupId) {
+        String transactionName = ctx.getStub().getTxId().split(":")[1];
         try {
             cUtil.checkParamsRemoveUserFromGroup(ctx, new ArrayList<String>(){{add(enrollmentId); add(groupId);}});
         } catch (SerializableError e) {
@@ -92,14 +95,17 @@ public class GroupContract extends ContractBase {
         group.getUserList().remove(enrollmentId);
 
         try {
-            cUtil.validateApprovals(stub, this.contractName, "removeUserFromGroup", new ArrayList<String>() {{add(enrollmentId);add(groupId);}});
+            cUtil.validateApprovals(stub, this.contractName, transactionName, new ArrayList<String>() {{add(enrollmentId);add(groupId);}});
         } catch (SerializableError e) {
             return e.getJsonError();
         }
 
         cUtil.putAndGetStringState(stub, groupId, GsonWrapper.toJson(group));
-
-        // success
+        try {
+            cUtil.finishOperation(stub, this.contractName, transactionName, new ArrayList<String>() {{add(enrollmentId);add(groupId);}});
+        } catch (SerializableError e) {
+            return e.getJsonError();
+        }
         return "";
     }
 
@@ -112,6 +118,7 @@ public class GroupContract extends ContractBase {
      */
     @Transaction()
     public String removeUserFromAllGroups(final Context ctx, String enrollmentId) {
+        String transactionName = ctx.getStub().getTxId().split(":")[1];
         try {
             cUtil.checkParamsRemoveUserFromAllGroups(Collections.singletonList(enrollmentId));
         } catch (ParameterError e) {
@@ -120,7 +127,7 @@ public class GroupContract extends ContractBase {
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(stub, this.contractName, "removeUserFromAllGroups", Collections.singletonList(enrollmentId));
+            cUtil.validateApprovals(stub, this.contractName, transactionName, Collections.singletonList(enrollmentId));
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -129,8 +136,11 @@ public class GroupContract extends ContractBase {
             item.getUserList().remove(enrollmentId);
             cUtil.putAndGetStringState(stub, item.getGroupId(), GsonWrapper.toJson(item));
         });
-
-        // success
+        try {
+            cUtil.finishOperation(stub, this.contractName, transactionName, Collections.singletonList(enrollmentId));
+        } catch (SerializableError e) {
+            return e.getJsonError();
+        }
         return "";
     }
 
@@ -142,13 +152,19 @@ public class GroupContract extends ContractBase {
      */
     @Transaction()
     public String getAllGroups(final Context ctx) {
+        String transactionName = ctx.getStub().getTxId().split(":")[1];
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(stub, this.contractName, "getAllGroups", new ArrayList<String>());
+            cUtil.validateApprovals(stub, this.contractName, transactionName, new ArrayList<String>());
         } catch (SerializableError e) {
             return e.getJsonError();
         }
         List<Group> groupList = cUtil.getAllGroups(stub);
+        try {
+            cUtil.finishOperation(stub, this.contractName, transactionName, new ArrayList<String>());
+        } catch (SerializableError e) {
+            return e.getJsonError();
+        }
         return GsonWrapper.toJson(groupList);
     }
 
@@ -160,6 +176,7 @@ public class GroupContract extends ContractBase {
      */
     @Transaction()
     public String getUsersForGroup(final Context ctx, String groupId) {
+        String transactionName = ctx.getStub().getTxId().split(":")[1];
         try {
             cUtil.checkParamsGetUsersForGroup(ctx, Collections.singletonList(groupId));
         } catch (SerializableError e) {
@@ -168,7 +185,7 @@ public class GroupContract extends ContractBase {
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(stub, this.contractName, "getUsersForGroup", Collections.singletonList(groupId));
+            cUtil.validateApprovals(stub, this.contractName, transactionName, Collections.singletonList(groupId));
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -178,7 +195,11 @@ public class GroupContract extends ContractBase {
         } catch (LedgerAccessError e) {
             return e.getJsonError();
         }
-
+        try {
+            cUtil.finishOperation(stub, this.contractName, transactionName, Collections.singletonList(groupId));
+        } catch (SerializableError e) {
+            return e.getJsonError();
+        }
         return GsonWrapper.toJson(userList);
     }
 
@@ -191,6 +212,7 @@ public class GroupContract extends ContractBase {
      */
     @Transaction()
     public String getGroupsForUser(final Context ctx, String enrollmentId) {
+        String transactionName = ctx.getStub().getTxId().split(":")[1];
         try {
             cUtil.checkParamsGetGroupsForUser(Collections.singletonList(enrollmentId));
         } catch (ParameterError e) {
@@ -199,12 +221,16 @@ public class GroupContract extends ContractBase {
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(stub, this.contractName, "getGroupsForUser", Collections.singletonList(enrollmentId));
+            cUtil.validateApprovals(stub, this.contractName, transactionName, Collections.singletonList(enrollmentId));
         } catch (SerializableError e) {
             return e.getJsonError();
         }
         List<String> groupIdList = cUtil.getGroupNamesForUser(stub, enrollmentId);
-
+        try {
+            cUtil.finishOperation(stub, this.contractName, transactionName, Collections.singletonList(enrollmentId));
+        } catch (SerializableError e) {
+            return e.getJsonError();
+        }
         return GsonWrapper.toJson(groupIdList);
     }
 }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/matriculationdata/MatriculationDataContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/matriculationdata/MatriculationDataContract.java
@@ -18,12 +18,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 @Contract(
-        name = "UC4.MatriculationData"
+        name = MatriculationDataContract.contractName
 )
 public class MatriculationDataContract extends ContractBase {
     private final MatriculationDataContractUtil cUtil = new MatriculationDataContractUtil();
 
-    public final String contractName = "UC4.MatriculationData";
+    public final static String contractName = "UC4.MatriculationData";
 
     /**
      * Adds MatriculationData to the ledger.
@@ -34,6 +34,7 @@ public class MatriculationDataContract extends ContractBase {
      */
     @Transaction()
     public String addMatriculationData(final Context ctx, String matriculationData) {
+        String transactionName = ctx.getStub().getTxId().split(":")[1];
         try {
             cUtil.checkParamsAddMatriculationData(ctx, Collections.singletonList(matriculationData));
         } catch (ParameterError e) {
@@ -42,12 +43,17 @@ public class MatriculationDataContract extends ContractBase {
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(stub, this.contractName,  "addMatriculationData", Collections.singletonList(matriculationData));
+            cUtil.validateApprovals(stub, this.contractName,  transactionName, Collections.singletonList(matriculationData));
         } catch (SerializableError e) {
             return e.getJsonError();
         }
 
         MatriculationData newMatriculationData = GsonWrapper.fromJson(matriculationData, MatriculationData.class);
+        try {
+            cUtil.finishOperation(stub, this.contractName,  transactionName, Collections.singletonList(matriculationData));
+        } catch (SerializableError e) {
+            return e.getJsonError();
+        }
         return cUtil.putAndGetStringState(stub, newMatriculationData.getEnrollmentId(), GsonWrapper.toJson(newMatriculationData));
     }
 
@@ -60,6 +66,7 @@ public class MatriculationDataContract extends ContractBase {
      */
     @Transaction()
     public String updateMatriculationData(final Context ctx, String matriculationData) {
+        String transactionName = ctx.getStub().getTxId().split(":")[1];
         try {
             cUtil.checkParamsUpdateMatriculationData(ctx, Collections.singletonList(matriculationData));
         } catch (ParameterError e) {
@@ -68,11 +75,16 @@ public class MatriculationDataContract extends ContractBase {
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(stub, this.contractName,  "updateMatriculationData", Collections.singletonList(matriculationData));
+            cUtil.validateApprovals(stub, this.contractName,  transactionName, Collections.singletonList(matriculationData));
         } catch (SerializableError e) {
             return e.getJsonError();
         }
         MatriculationData newMatriculationData = GsonWrapper.fromJson(matriculationData, MatriculationData.class);
+        try {
+            cUtil.finishOperation(stub, this.contractName,  transactionName, Collections.singletonList(matriculationData));
+        } catch (SerializableError e) {
+            return e.getJsonError();
+        }
         return cUtil.putAndGetStringState(stub, newMatriculationData.getEnrollmentId(), GsonWrapper.toJson(newMatriculationData));
     }
 
@@ -85,6 +97,7 @@ public class MatriculationDataContract extends ContractBase {
      */
     @Transaction()
     public String getMatriculationData(final Context ctx, final String enrollmentId) {
+        String transactionName = ctx.getStub().getTxId().split(":")[1];
         try {
             cUtil.checkParamsGetMatriculationData(ctx, Collections.singletonList(enrollmentId));
         } catch (ParameterError e) {
@@ -93,7 +106,7 @@ public class MatriculationDataContract extends ContractBase {
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(stub, this.contractName,  "getMatriculationData", Collections.singletonList(enrollmentId));
+            cUtil.validateApprovals(stub, this.contractName,  transactionName, Collections.singletonList(enrollmentId));
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -101,6 +114,11 @@ public class MatriculationDataContract extends ContractBase {
         try {
             matriculationData = cUtil.getState(stub, enrollmentId, MatriculationData.class);
         } catch (LedgerAccessError e) {
+            return e.getJsonError();
+        }
+        try {
+            cUtil.finishOperation(stub, this.contractName,  transactionName, Collections.singletonList(enrollmentId));
+        } catch (SerializableError e) {
             return e.getJsonError();
         }
         return GsonWrapper.toJson(matriculationData);
@@ -119,6 +137,7 @@ public class MatriculationDataContract extends ContractBase {
             final Context ctx,
             final String enrollmentId,
             final String matriculations) {
+        String transactionName = ctx.getStub().getTxId().split(":")[1];
         try {
             cUtil.checkParamsAddEntriesToMatriculationData(ctx, new ArrayList<String>(){{add(enrollmentId); add(matriculations);}});
         } catch (SerializableError e) {
@@ -127,7 +146,7 @@ public class MatriculationDataContract extends ContractBase {
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(stub, this.contractName,  "addEntriesToMatriculationData", new ArrayList<String>() {{add(enrollmentId); add(matriculations);}});
+            cUtil.validateApprovals(stub, this.contractName,  transactionName, new ArrayList<String>() {{add(enrollmentId); add(matriculations);}});
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -143,6 +162,11 @@ public class MatriculationDataContract extends ContractBase {
         }
 
         matriculationData.addAbsent(matriculationStatus);
+        try {
+            cUtil.finishOperation(stub, this.contractName,  transactionName, new ArrayList<String>() {{add(enrollmentId); add(matriculations);}});
+        } catch (SerializableError e) {
+            return e.getJsonError();
+        }
         return cUtil.putAndGetStringState(stub, matriculationData.getEnrollmentId(), GsonWrapper.toJson(matriculationData));
     }
 }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/operation/OperationContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/operation/OperationContract.java
@@ -81,11 +81,10 @@ public class OperationContract extends ContractBase {
             return e.getJsonError();
         }
         ApprovalList missingApprovals = OperationContractUtil.getMissingApprovalList(requiredApprovals, existingApprovals);
-        OperationData result = operationData
-                .lastModifiedTimestamp(timeStamp)
+        operationData.lastModifiedTimestamp(timeStamp)
                 .existingApprovals(existingApprovals)
                 .missingApprovals(missingApprovals);
-        return cUtil.putAndGetStringState(ctx.getStub(), key, GsonWrapper.toJson(result));
+        return cUtil.putAndGetStringState(ctx.getStub(), key, GsonWrapper.toJson(operationData));
     }
 
     @Transaction

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/AccessManager.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/AccessManager.java
@@ -1,6 +1,11 @@
 package de.upb.cs.uc4.chaincode.helper;
 
 import com.google.gson.reflect.TypeToken;
+import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContract;
+import de.upb.cs.uc4.chaincode.contract.certificate.CertificateContract;
+import de.upb.cs.uc4.chaincode.contract.examinationregulation.ExaminationRegulationContract;
+import de.upb.cs.uc4.chaincode.contract.group.GroupContract;
+import de.upb.cs.uc4.chaincode.contract.matriculationdata.MatriculationDataContract;
 import de.upb.cs.uc4.chaincode.contract.operation.OperationContractUtil;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.parameter.MissingTransactionError;
 import de.upb.cs.uc4.chaincode.model.ApprovalList;
@@ -20,7 +25,7 @@ public class AccessManager {
         }.getType();
         List<String> paramList = GsonWrapper.fromJson(params, listType);
         switch (contractName) {
-            case "UC4.MatriculationData":
+            case MatriculationDataContract.contractName:
                 switch (transactionName) {
                     case "addMatriculationData":
                         return getRequiredApprovalsForAddMatriculationData(paramList);
@@ -35,7 +40,7 @@ public class AccessManager {
                     default:
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getTransactionUnprocessableError(transactionName)));
                 }
-            case "UC4.Admission":
+            case AdmissionContract.contractName:
                 switch (transactionName) {
                     case "addAdmission":
                         return getRequiredApprovalsForAddAdmission(paramList);
@@ -48,7 +53,7 @@ public class AccessManager {
                     default:
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getTransactionUnprocessableError(transactionName)));
                 }
-            case "UC4.Group":
+            case GroupContract.contractName:
                 switch (transactionName) {
                     case "addUserToGroup":
                         return getRequiredApprovalsForAddUserToGroup(paramList);
@@ -67,7 +72,7 @@ public class AccessManager {
                     default:
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getTransactionUnprocessableError(transactionName)));
                 }
-            case "UC4.Certificate":
+            case CertificateContract.contractName:
                 switch (transactionName) {
                     case "addCertificate":
                         return getRequiredApprovalsForAddCertificate(paramList);
@@ -80,7 +85,7 @@ public class AccessManager {
                     default:
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getTransactionUnprocessableError(transactionName)));
                 }
-            case "UC4.ExaminationRegulation":
+            case ExaminationRegulationContract.contractName:
                 switch (transactionName) {
                     case "addExaminationRegulation":
                         return getRequiredApprovalsForAddExaminationRegulation(paramList);

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/ValidationManager.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/ValidationManager.java
@@ -1,10 +1,15 @@
 package de.upb.cs.uc4.chaincode.helper;
 
 import com.google.gson.reflect.TypeToken;
+import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContract;
 import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContractUtil;
+import de.upb.cs.uc4.chaincode.contract.certificate.CertificateContract;
 import de.upb.cs.uc4.chaincode.contract.certificate.CertificateContractUtil;
+import de.upb.cs.uc4.chaincode.contract.examinationregulation.ExaminationRegulationContract;
 import de.upb.cs.uc4.chaincode.contract.examinationregulation.ExaminationRegulationContractUtil;
+import de.upb.cs.uc4.chaincode.contract.group.GroupContract;
 import de.upb.cs.uc4.chaincode.contract.group.GroupContractUtil;
+import de.upb.cs.uc4.chaincode.contract.matriculationdata.MatriculationDataContract;
 import de.upb.cs.uc4.chaincode.contract.matriculationdata.MatriculationDataContractUtil;
 import de.upb.cs.uc4.chaincode.contract.operation.OperationContractUtil;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.ParameterError;
@@ -28,7 +33,7 @@ public class ValidationManager {
         Type listType = new TypeToken<ArrayList<String>>() {}.getType();
         List<String> paramList = GsonWrapper.fromJson(params, listType);
         switch (contractName) {
-            case "UC4.MatriculationData":
+            case MatriculationDataContract.contractName:
                 switch (transactionName) {
                     case "addMatriculationData":
                         matriculationDataUtil.checkParamsAddMatriculationData(ctx, paramList);
@@ -48,7 +53,7 @@ public class ValidationManager {
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getTransactionUnprocessableError(transactionName)));
                 }
                 break;
-            case "UC4.Admission":
+            case AdmissionContract.contractName:
                 switch (transactionName) {
                     case "addAdmission":
                         admissionUtil.checkParamsAddAdmission(ctx, paramList);
@@ -65,7 +70,7 @@ public class ValidationManager {
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getTransactionUnprocessableError(transactionName)));
                 }
                 break;
-            case "UC4.Group":
+            case GroupContract.contractName:
                 switch (transactionName) {
                     case "addUserToGroup":
                         groupUtil.checkParamsAddUserToGroup(ctx, paramList);
@@ -91,7 +96,7 @@ public class ValidationManager {
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getTransactionUnprocessableError(transactionName)));
                 }
                 break;
-            case "UC4.ExaminationRegulation":
+            case ExaminationRegulationContract.contractName:
                 switch (transactionName) {
                     case "addExaminationRegulation":
                         examinationRegulationUtil.checkParamsAddExaminationRegulation(ctx, paramList);
@@ -108,7 +113,7 @@ public class ValidationManager {
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getTransactionUnprocessableError(transactionName)));
                 }
                 break;
-            case "UC4.Certificate":
+            case CertificateContract.contractName:
                 switch (transactionName) {
                     case "addCertificate":
                         certificateUtil.checkParamsAddCertificate(ctx, paramList);

--- a/UC4-chaincode/src/main/resources/project.properties
+++ b/UC4-chaincode/src/main/resources/project.properties
@@ -1,3 +1,3 @@
 #
-#Fri Jan 15 15:04:56 CET 2021
-rootVersion=0.15.1-9
+#Fri Jan 15 15:28:27 CET 2021
+rootVersion=0.15.1-15

--- a/UC4-chaincode/src/main/resources/project.properties
+++ b/UC4-chaincode/src/main/resources/project.properties
@@ -1,3 +1,3 @@
 #
-#Tue Jan 12 14:53:19 CET 2021
-rootVersion=0.15.1-2
+#Tue Jan 12 17:50:00 CET 2021
+rootVersion=0.15.1-8

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/AdmissionContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/AdmissionContractTest.java
@@ -120,7 +120,7 @@ public final class AdmissionContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Admission:dropAdmision");
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Admission:dropAdmission");
             OperationContract approvalContract = new OperationContract();
             for (String id : ids) {
                 Context ctx = TestUtil.mockContext(stub, id);

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/AdmissionContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/AdmissionContractTest.java
@@ -55,7 +55,7 @@ public final class AdmissionContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Admission:addAdmission");
             OperationContract approvalContract = new OperationContract();
             for (String id : ids) {
                 Context ctx = TestUtil.mockContext(stub, id);
@@ -79,7 +79,7 @@ public final class AdmissionContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Admission:addAdmission");
             OperationContract approvalContract = new OperationContract();
             for (String id : ids) {
                 Context ctx = TestUtil.mockContext(stub, id);
@@ -98,7 +98,7 @@ public final class AdmissionContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Admission:dropAdmission");
             OperationContract approvalContract = new OperationContract();
             for (String id : ids) {
                 Context ctx = TestUtil.mockContext(stub, id);
@@ -120,7 +120,7 @@ public final class AdmissionContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Admission:dropAdmision");
             OperationContract approvalContract = new OperationContract();
             for (String id : ids) {
                 Context ctx = TestUtil.mockContext(stub, id);
@@ -138,7 +138,7 @@ public final class AdmissionContractTest extends TestCreationBase {
             List<String> compare
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Admission:getAdmissions");
             Context ctx = TestUtil.mockContext(stub);
             String getResult = contract.getAdmissions(ctx, input.get(0), input.get(1), input.get(2));
             assertThat(getResult).isEqualTo(compare.get(0));

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/CertificateContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/CertificateContractTest.java
@@ -128,7 +128,7 @@ public final class CertificateContractTest extends TestCreationBase {
             List<String> compare
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Certificate:getCertificate");
             Context ctx = TestUtil.mockContext(stub);
 
             String certificate = contract.getCertificate(ctx, input.get(0));
@@ -142,7 +142,7 @@ public final class CertificateContractTest extends TestCreationBase {
             List<String> compare
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Certificate:addCertificate");
             Context ctx = TestUtil.mockContext(stub);
 
             assertThat(contract.addCertificate(ctx, input.get(0), input.get(1)))
@@ -158,7 +158,7 @@ public final class CertificateContractTest extends TestCreationBase {
             List<String> compare
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Certificate:addCertificate");
             Context ctx = TestUtil.mockContext(stub);
 
             String result = contract.addCertificate(ctx, input.get(0), input.get(1));
@@ -172,7 +172,7 @@ public final class CertificateContractTest extends TestCreationBase {
             List<String> compare
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Certificate:updateCertificate");
             Context ctx = TestUtil.mockContext(stub);
 
             assertThat(contract.updateCertificate(ctx, input.get(0), input.get(1)))
@@ -189,7 +189,7 @@ public final class CertificateContractTest extends TestCreationBase {
             List<String> compare
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Certificate:updateCertificate");
             Context ctx = TestUtil.mockContext(stub);
 
             String result = contract.updateCertificate(ctx, input.get(0), input.get(1));

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/ExaminationRegulationContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/ExaminationRegulationContractTest.java
@@ -55,7 +55,7 @@ public final class ExaminationRegulationContractTest extends TestCreationBase {
             List<String> compare
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.ExaminationRegulation:getExaminationRegulations");
             Context ctx = TestUtil.mockContext(stub);
 
             String regulations = contract.getExaminationRegulations(ctx, input.get(0));
@@ -69,7 +69,7 @@ public final class ExaminationRegulationContractTest extends TestCreationBase {
             List<String> compare
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.ExaminationRegulation:addExaminationRegulation");
             Context ctx = TestUtil.mockContext(stub);
 
             String result = contract.addExaminationRegulation(ctx, input.get(0));
@@ -88,7 +88,7 @@ public final class ExaminationRegulationContractTest extends TestCreationBase {
             List<String> compare
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.ExaminationRegulation:addExaminationRegulation");
             Context ctx = TestUtil.mockContext(stub);
 
             String result = contract.addExaminationRegulation(ctx, input.get(0));
@@ -102,7 +102,7 @@ public final class ExaminationRegulationContractTest extends TestCreationBase {
             List<String> compare
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.ExaminationRegulation:closeExaminationRegulation");
             Context ctx = TestUtil.mockContext(stub);
 
             String result = contract.closeExaminationRegulation(ctx, input.get(0));
@@ -121,7 +121,7 @@ public final class ExaminationRegulationContractTest extends TestCreationBase {
             List<String> compare
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.ExaminationRegulation:closeExaminationRegulation");
             Context ctx = TestUtil.mockContext(stub);
 
             String result = contract.closeExaminationRegulation(ctx, input.get(0));

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/GroupContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/GroupContractTest.java
@@ -68,7 +68,7 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:addUserToGroup");
             OperationContract approvalContract = new OperationContract();
             for (String id: ids) {
                 Context ctx = TestUtil.mockContext(stub, id);
@@ -92,7 +92,7 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:addUserToGroup");
             OperationContract approvalContract = new OperationContract();
             for (String id: ids) {
                 Context ctx = TestUtil.mockContext(stub, id);
@@ -113,7 +113,7 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:removeUserFromGroup");
             OperationContract approvalContract = new OperationContract();
             for (String id: ids) {
                 Context ctx = TestUtil.mockContext(stub, id);
@@ -140,7 +140,7 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:removeUserFromGroup");
             OperationContract approvalContract = new OperationContract();
             for (String id: ids) {
                 Context ctx = TestUtil.mockContext(stub, id);
@@ -160,7 +160,7 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:removeUserFromAllGroups");
             OperationContract approvalContract = new OperationContract();
             for (String id: ids) {
                 Context ctx = TestUtil.mockContext(stub, id);
@@ -187,7 +187,7 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:removeUserFromAllGroups");
             OperationContract approvalContract = new OperationContract();
             for (String id: ids) {
                 Context ctx = TestUtil.mockContext(stub, id);
@@ -209,7 +209,7 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:getAllGroups");
             OperationContract approvalContract = new OperationContract();
             for (String id: ids) {
                 Context ctx = TestUtil.mockContext(stub, id);
@@ -229,7 +229,7 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:getUsersForGroup");
             OperationContract approvalContract = new OperationContract();
             for (String id: ids) {
                 Context ctx = TestUtil.mockContext(stub, id);
@@ -249,7 +249,7 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:getUsersForGroup");
             OperationContract approvalContract = new OperationContract();
             for (String id: ids) {
                 Context ctx = TestUtil.mockContext(stub, id);
@@ -268,7 +268,7 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:getGroupsForUser");
             OperationContract approvalContract = new OperationContract();
             for (String id: ids) {
                 Context ctx = TestUtil.mockContext(stub, id);
@@ -288,7 +288,7 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:getGroupsForUser");
             OperationContract approvalContract = new OperationContract();
             for (String id: ids) {
                 Context ctx = TestUtil.mockContext(stub, id);

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/MatriculationDataContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/MatriculationDataContractTest.java
@@ -48,10 +48,10 @@ public final class MatriculationDataContractTest extends TestCreationBase {
                 return DynamicTest.dynamicTest(testName, updateMatriculationDataSuccessTest(setup, input, compare));
             case "updateMatriculationData_FAILURE":
                 return DynamicTest.dynamicTest(testName, updateMatriculationDataFailureTest(setup, input, compare));
-            case "addEntryToMatriculationData_SUCCESS":
-                return DynamicTest.dynamicTest(testName, addEntryToMatriculationDataSuccessTest(setup, input, compare));
-            case "addEntryToMatriculationData_FAILURE":
-                return DynamicTest.dynamicTest(testName, addEntryToMatriculationDataFailureTest(setup, input, compare));
+            case "addEntriesToMatriculationData_SUCCESS":
+                return DynamicTest.dynamicTest(testName, addEntriesToMatriculationDataSuccessTest(setup, input, compare));
+            case "addEntriesToMatriculationData_FAILURE":
+                return DynamicTest.dynamicTest(testName, addEntriesToMatriculationDataFailureTest(setup, input, compare));
             default:
                 throw new RuntimeException("Test " + testName + " of type " + testType + " could not be matched.");
         }
@@ -63,7 +63,7 @@ public final class MatriculationDataContractTest extends TestCreationBase {
             List<String> compare
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.MatriculationData:getMatriculationData");
             Context ctx = TestUtil.mockContext(stub);
 
             MatriculationData compareMatriculationData = GsonWrapper.fromJson(compare.get(0), MatriculationData.class);
@@ -80,7 +80,7 @@ public final class MatriculationDataContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.MatriculationData:addMatriculationData");
             OperationContract operationContract = new OperationContract();
             for (String id : ids) {
                 Context ctx = TestUtil.mockContext(stub, id);
@@ -107,7 +107,7 @@ public final class MatriculationDataContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.MatriculationData:addMatriculationData");
             OperationContract approvalContract = new OperationContract();
             for (String id: ids) {
                 Context ctx = TestUtil.mockContext(stub, id);
@@ -126,7 +126,7 @@ public final class MatriculationDataContractTest extends TestCreationBase {
             List<String> compare
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.MatriculationData:updateMatriculationData");
             Context ctx = TestUtil.mockContext(stub);
 
             String result = contract.updateMatriculationData(ctx, input.get(0));
@@ -146,7 +146,7 @@ public final class MatriculationDataContractTest extends TestCreationBase {
             List<String> compare
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.MatriculationData:updateMatriculationData");
             Context ctx = TestUtil.mockContext(stub);
 
             String result = contract.updateMatriculationData(ctx, input.get(0));
@@ -154,13 +154,13 @@ public final class MatriculationDataContractTest extends TestCreationBase {
         };
     }
 
-    private Executable addEntryToMatriculationDataSuccessTest(
+    private Executable addEntriesToMatriculationDataSuccessTest(
             JsonIOTestSetup setup,
             List<String> input,
             List<String> compare
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.MatriculationData:addEntriesToMatriculationData");
             Context ctx = TestUtil.mockContext(stub);
 
             String result = contract.addEntriesToMatriculationData(ctx, input.get(0), input.get(1));
@@ -173,13 +173,13 @@ public final class MatriculationDataContractTest extends TestCreationBase {
         };
     }
 
-    private Executable addEntryToMatriculationDataFailureTest(
+    private Executable addEntriesToMatriculationDataFailureTest(
             JsonIOTestSetup setup,
             List<String> input,
             List<String> compare
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup);
+            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.MatriculationData:addEntriesToMatriculationData");
             Context ctx = TestUtil.mockContext(stub);
 
             String result = contract.addEntriesToMatriculationData(ctx, input.get(0), input.get(1));

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/mock/MockChaincodeStub.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/mock/MockChaincodeStub.java
@@ -22,15 +22,20 @@ public final class MockChaincodeStub implements ChaincodeStub {
     private final String defaultCollection = "default";
     private Map<String, byte[]> transientMap;
     private String currentId;
-    private Instant txTimeStamp;
+    private String txId;
 
     public void setCurrentId(String currentId) {
         this.currentId = currentId;
     }
 
-    public MockChaincodeStub() {
+    public MockChaincodeStub(String txId) {
+        this.txId = txId;
         dataCollections = new HashMap<>();
         dataCollections.put(defaultCollection, new ArrayList<>());
+    }
+
+    public void setTxId(String txId) {
+        this.txId = txId;
     }
 
     public void setTransient(Map<String, byte[]> transientMap) {
@@ -119,7 +124,7 @@ public final class MockChaincodeStub implements ChaincodeStub {
 
     @Override
     public String getTxId() {
-        return null;
+        return txId;
     }
 
     @Override

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/util/TestUtil.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/util/TestUtil.java
@@ -35,8 +35,8 @@ public class TestUtil {
         return ctx;
     }
 
-    public static MockChaincodeStub mockStub(JsonIOTestSetup setup) {
-        MockChaincodeStub stub = new MockChaincodeStub();
+    public static MockChaincodeStub mockStub(JsonIOTestSetup setup, String txId) {
+        MockChaincodeStub stub = new MockChaincodeStub(txId);
         setup.prepareStub(stub);
         return stub;
     }

--- a/UC4-chaincode/src/test/resources/test_configs/matriculation_data_contract/AddEntriesToMatriculationDataTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/matriculation_data_contract/AddEntriesToMatriculationDataTestIO.json
@@ -1,7 +1,7 @@
 [
   {
-    "name": "addEntryToExistingSubjectOfExistingMatriculationData",
-    "type": "addEntryToMatriculationData_SUCCESS",
+    "name": "addEntriesToExistingSubjectOfExistingMatriculationData",
+    "type": "addEntriesToMatriculationData_SUCCESS",
     "setup": {
       "matriculationDataContract": [
         "0000001",
@@ -53,8 +53,8 @@
     ]
   },
   {
-    "name": "addEntryToNonExistingSubjectOfExistingMatriculationData",
-    "type": "addEntryToMatriculationData_SUCCESS",
+    "name": "addEntriesToNonExistingSubjectOfExistingMatriculationData",
+    "type": "addEntriesToMatriculationData_SUCCESS",
     "setup": {
       "matriculationDataContract": [
         "0000001",
@@ -118,7 +118,7 @@
   },
   {
     "name": "addExistingEntryToExistingMatriculationData",
-    "type": "addEntryToMatriculationData_SUCCESS",
+    "type": "addEntriesToMatriculationData_SUCCESS",
     "setup": {
       "matriculationDataContract": [
         "0000001",
@@ -170,7 +170,7 @@
   },
   {
     "name": "addTwoEntriesToExistingSubjectOfExistingMatriculationData",
-    "type": "addEntryToMatriculationData_SUCCESS",
+    "type": "addEntriesToMatriculationData_SUCCESS",
     "setup": {
       "matriculationDataContract": [
         "0000001",
@@ -241,7 +241,7 @@
   },
   {
     "name": "addMultipleEntriesToExistingSubjectOfExistingMatriculationData",
-    "type": "addEntryToMatriculationData_SUCCESS",
+    "type": "addEntriesToMatriculationData_SUCCESS",
     "setup": {
       "matriculationDataContract": [
         "0000001",
@@ -330,7 +330,7 @@
   },
   {
     "name": "addMultipleEntriesToExistingSubjectOfExistingMatriculationData",
-    "type": "addEntryToMatriculationData_SUCCESS",
+    "type": "addEntriesToMatriculationData_SUCCESS",
     "setup": {
       "matriculationDataContract": [
         "0000001",
@@ -431,7 +431,7 @@
   },
   {
     "name": "addMultipleInvalidEntriesToExistingSubjectOfExistingMatriculationData",
-    "type": "addEntryToMatriculationData_FAILURE",
+    "type": "addEntriesToMatriculationData_FAILURE",
     "setup": {
       "matriculationDataContract": [
         "0000001",
@@ -498,7 +498,7 @@
   },
   {
     "name": "addInvalidSemesterEntryToExistingMatriculationData",
-    "type": "addEntryToMatriculationData_FAILURE",
+    "type": "addEntriesToMatriculationData_FAILURE",
     "setup": {
       "matriculationDataContract": [
         "0000001",
@@ -549,7 +549,7 @@
   },
   {
     "name": "addNonExistingEnrollmentIdEntryToExistingMatriculationData",
-    "type": "addEntryToMatriculationData_FAILURE",
+    "type": "addEntriesToMatriculationData_FAILURE",
     "setup": {
       "matriculationDataContract": [
         "0000001",
@@ -594,7 +594,7 @@
   },
   {
     "name": "addEmptyEnrollmentIdEntryToMatriculationData",
-    "type": "addEntryToMatriculationData_FAILURE",
+    "type": "addEntriesToMatriculationData_FAILURE",
     "setup": {
       "examinationRegulationContract": [
         "Computer Science",
@@ -630,8 +630,8 @@
     ]
   },
   {
-    "name": "addEntryToUnprocessableMatriculationData",
-    "type": "addEntryToMatriculationData_FAILURE",
+    "name": "addEntriesToUnprocessableMatriculationData",
+    "type": "addEntriesToMatriculationData_FAILURE",
     "setup": {
       "matriculationDataContract": [
         "0000001",
@@ -666,7 +666,7 @@
   },
   {
     "name": "addUnprocessableMatriculationDataToEntry",
-    "type": "addEntryToMatriculationData_FAILURE",
+    "type": "addEntriesToMatriculationData_FAILURE",
     "setup": {
       "matriculationDataContract": [
         "0000001",

--- a/UC4-chaincode/src/test/resources/test_configs/operation_contract/FinishOperationTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/operation_contract/FinishOperationTestIO.json
@@ -1,0 +1,78 @@
+[
+  {
+    "name": "finishSuccessfulOperation",
+    "type": "finishOperation",
+    "ids": [
+      "User1",
+      "0000001"
+    ],
+    "setup": {
+      "examinationRegulationContract": [
+        "Computer Science",
+        {
+          "name": "Computer Science",
+          "active": true,
+          "modules": []
+        }
+      ],
+      "groupContract": [
+        "admin",
+        {
+          "groupId": "admin",
+          "userList": [
+            "User1"
+          ]
+        }
+      ]
+    },
+    "input": [
+      {
+        "enrollmentId": "User1",
+        "matriculationStatus": [
+          {
+            "fieldOfStudy": "Computer Science",
+            "semesters": [
+              "WS2018/19"
+            ]
+          }
+        ]
+      }
+    ],
+    "compare": [
+      "FINISHED"
+    ]
+  },
+  {
+    "name": "leaveUnsuccessfulOperationPending",
+    "type": "finishOperation",
+    "ids": [
+      "0000001"
+    ],
+    "setup": {
+      "examinationRegulationContract": [
+        "Computer Science",
+        {
+          "name": "Computer Science",
+          "active": true,
+          "modules": []
+        }
+      ]
+    },
+    "input": [
+      {
+        "enrollmentId": "User1",
+        "matriculationStatus": [
+          {
+            "fieldOfStudy": "Computer Science",
+            "semesters": [
+              "WS2018/19"
+            ]
+          }
+        ]
+      }
+    ],
+    "compare": [
+      "PENDING"
+    ]
+  }
+]

--- a/UC4-chaincode/src/test/resources/test_configs/operation_contract/FinishOperationTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/operation_contract/FinishOperationTestIO.json
@@ -16,9 +16,9 @@
         }
       ],
       "groupContract": [
-        "admin",
+        "Admin",
         {
-          "groupId": "admin",
+          "groupId": "Admin",
           "userList": [
             "User1"
           ]


### PR DESCRIPTION
### Reason for this PR
- successful execution of a transaction should leave the corresponding operation in "FINISHED" state

### Changes in this PR
- set operation state to FINISHED on successful transaction execution
- read transactionId from stub
- read annotated contract name from static contract name
- add tests for operation state after transaction execution
