### PR TITLE
Rename admin group

### DIFF
--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/AccessManager.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/AccessManager.java
@@ -13,7 +13,7 @@ import java.util.List;
 public class AccessManager {
     private static OperationContractUtil operationUtil = new OperationContractUtil();
 
-    public static final String ADMIN = "admin";
+    public static final String ADMIN = "Admin";
 
     public static ApprovalList getRequiredApprovals(String contractName, String transactionName, String params) throws MissingTransactionError {
         Type listType = new TypeToken<ArrayList<String>>() {

--- a/UC4-chaincode/src/main/resources/project.properties
+++ b/UC4-chaincode/src/main/resources/project.properties
@@ -1,3 +1,3 @@
 #
-#Tue Jan 12 14:53:19 CET 2021
-rootVersion=0.15.1-2
+#Fri Jan 15 15:04:56 CET 2021
+rootVersion=0.15.1-9

--- a/UC4-chaincode/src/test/resources/test_configs/admission_contract/AddAdmissionTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/admission_contract/AddAdmissionTestIO.json
@@ -39,9 +39,9 @@
         }
       ],
       "groupContract": [
-        "admin",
+        "Admin",
         {
-          "groupId": "admin",
+          "groupId": "Admin",
           "userList": [
             "User1"
           ]

--- a/UC4-chaincode/src/test/resources/test_configs/admission_contract/DropAdmissionTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/admission_contract/DropAdmissionTestIO.json
@@ -49,9 +49,9 @@
         }
       ],
       "groupContract": [
-        "admin",
+        "Admin",
         {
-          "groupId": "admin",
+          "groupId": "Admin",
           "userList": [
             "User1"
           ]

--- a/UC4-chaincode/src/test/resources/test_configs/matriculation_data_contract/AddMatriculationDataTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/matriculation_data_contract/AddMatriculationDataTestIO.json
@@ -16,9 +16,9 @@
         }
       ],
       "groupContract": [
-        "admin",
+        "Admin",
         {
-          "groupId": "admin",
+          "groupId": "Admin",
           "userList": [
             "User1"
           ]
@@ -70,9 +70,9 @@
         }
       ],
       "groupContract": [
-        "admin",
+        "Admin",
         {
-          "groupId": "admin",
+          "groupId": "Admin",
           "userList": ["User1"]
         }
       ]
@@ -157,9 +157,9 @@
         }
       ],
       "groupContract": [
-        "admin",
+        "Admin",
         {
-          "groupId": "admin",
+          "groupId": "Admin",
           "userList": [
             "User1"
           ]
@@ -493,9 +493,9 @@
         }
       ],
       "groupContract": [
-        "admin",
+        "Admin",
         {
-          "groupId": "admin",
+          "groupId": "Admin",
           "userList": [
             "User1"
           ]

--- a/UC4-chaincode/src/test/resources/test_configs/operation_contract/ApproveTransactionTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/operation_contract/ApproveTransactionTestIO.json
@@ -15,9 +15,9 @@
         }
       ],
       "groupContract": [
-        "admin",
+        "Admin",
         {
-          "groupId": "admin",
+          "groupId": "Admin",
           "userList": [
             "User1"
           ]
@@ -57,7 +57,7 @@
             "User1"
           ],
           "groups": [
-            "admin"
+            "Admin"
           ]
         },
         "missingApprovals": {
@@ -104,9 +104,9 @@
         }
       ],
       "groupContract": [
-        "admin",
+        "Admin",
         {
-          "groupId": "admin",
+          "groupId": "Admin",
           "userList": [
             "User1"
           ]
@@ -157,7 +157,7 @@
           ],
           "groups": [
             "some-group",
-            "admin"
+            "Admin"
           ]
         },
         "missingApprovals": {
@@ -194,7 +194,7 @@
               "User2"
             ],
             "groups": [
-              "admin"
+              "Admin"
             ]
           },
           "missingApprovals": {
@@ -204,9 +204,9 @@
         }
       ],
       "groupContract": [
-        "admin",
+        "Admin",
         {
-          "groupId": "admin",
+          "groupId": "Admin",
           "userList": [
             "User1"
           ]
@@ -255,7 +255,7 @@
             "User2"
           ],
           "groups": [
-            "admin"
+            "Admin"
           ]
         },
         "missingApprovals": {
@@ -392,7 +392,7 @@
         "missingApprovals": {
           "users": [],
           "groups": [
-            "admin"
+            "Admin"
           ]
         }
       }
@@ -414,9 +414,9 @@
         }
       ],
       "groupContract": [
-        "admin",
+        "Admin",
         {
-          "groupId": "admin",
+          "groupId": "Admin",
           "userList": [
             "User1"
           ]
@@ -450,9 +450,9 @@
         }
       ],
       "groupContract": [
-        "admin",
+        "Admin",
         {
-          "groupId": "admin",
+          "groupId": "Admin",
           "userList": [
             "User1"
           ]

--- a/UC4-chaincode/src/test/resources/test_configs/operation_contract/GetOperationDataTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/operation_contract/GetOperationDataTestIO.json
@@ -26,7 +26,7 @@
           },
           "missingApprovals": {
             "users": [
-              "admin"
+              "Admin"
             ],
             "groups": []
           }
@@ -55,7 +55,7 @@
         },
         "missingApprovals": {
           "users": [
-            "admin"
+            "Admin"
           ],
           "groups": []
         }
@@ -89,7 +89,7 @@
           },
           "missingApprovals": {
             "users": [
-              "admin"
+              "Admin"
             ],
             "groups": []
           }
@@ -118,7 +118,7 @@
         },
         "missingApprovals": {
           "users": [
-            "admin"
+            "Admin"
           ],
           "groups": []
         }
@@ -152,7 +152,7 @@
           },
           "missingApprovals": {
             "users": [
-              "admin"
+              "Admin"
             ],
             "groups": []
           }
@@ -181,7 +181,7 @@
         },
         "missingApprovals": {
           "users": [
-            "admin"
+            "Admin"
           ],
           "groups": []
         }

--- a/UC4-chaincode/src/test/resources/test_configs/operation_contract/GetOperationsTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/operation_contract/GetOperationsTestIO.json
@@ -28,7 +28,7 @@
           },
           "missingApprovals": {
             "users": [
-              "admin"
+              "Admin"
             ],
             "groups": []
           }
@@ -76,7 +76,7 @@
           },
           "missingApprovals": {
             "users": [
-              "admin"
+              "Admin"
             ],
             "groups": []
           }
@@ -103,7 +103,7 @@
           },
           "missingApprovals": {
             "users": [
-              "admin"
+              "Admin"
             ],
             "groups": []
           }
@@ -131,7 +131,7 @@
           },
           "missingApprovals": {
             "users": [
-              "admin",
+              "Admin",
               "some-group"
             ],
             "groups": []
@@ -240,10 +240,10 @@
           },
           "missingApprovals": {
             "users": [
-              "admin"
+              "Admin"
             ],
             "groups": [
-              "admin"
+              "Admin"
             ]
           }
         },
@@ -269,7 +269,7 @@
           },
           "missingApprovals": {
             "users": [
-              "admin",
+              "Admin",
               "User4",
               "User5"
             ],
@@ -301,7 +301,7 @@
           },
           "missingApprovals": {
             "users": [
-              "admin",
+              "Admin",
               "some-group",
               "User4"
             ],
@@ -310,9 +310,9 @@
         }
       ],
       "groupContract": [
-        "admin",
+        "Admin",
         {
-          "groupId": "admin",
+          "groupId": "Admin",
           "userList": [
             "User1",
             "User5"

--- a/UC4-chaincode/src/test/resources/test_configs/operation_contract/RejectTransactionTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/operation_contract/RejectTransactionTestIO.json
@@ -26,7 +26,7 @@
           },
           "missingApprovals": {
             "users": [
-              "admin"
+              "Admin"
             ],
             "groups": []
           }
@@ -56,7 +56,7 @@
         },
         "missingApprovals": {
           "users": [
-            "admin"
+            "Admin"
           ],
           "groups": []
         }
@@ -90,7 +90,7 @@
           },
           "missingApprovals": {
             "users": [
-              "admin"
+              "Admin"
             ],
             "groups": ""
           }
@@ -135,7 +135,7 @@
           },
           "missingApprovals": {
             "users": [
-              "admin"
+              "Admin"
             ],
             "groups": ""
           },


### PR DESCRIPTION
### Reason for this PR
- admin group was named inconsistent with lagom system

### Changes in this PR
- rename admin group
