### PR TITLE
Remove additional info from rejection message

### DIFF
--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/operation/OperationContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/operation/OperationContractUtil.java
@@ -30,7 +30,7 @@ public class OperationContractUtil extends ContractUtil {
     }
 
     public String getUserRejectionMessage(String message) {
-        return "A User denied with the following message: " + message;
+        return message;
     }
 
     public String getSystemDetailedRejectionMessage(DetailedError error) {

--- a/UC4-chaincode/src/main/resources/project.properties
+++ b/UC4-chaincode/src/main/resources/project.properties
@@ -1,3 +1,3 @@
 #
-#Fri Jan 15 17:51:35 CET 2021
-rootVersion=0.15.2-2
+#Tue Jan 19 16:09:35 CET 2021
+rootVersion=0.15.2-4

--- a/UC4-chaincode/src/test/resources/test_configs/operation_contract/RejectTransactionTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/operation_contract/RejectTransactionTestIO.json
@@ -49,7 +49,7 @@
         "initiatedTimestamp":  "",
         "lastModifiedTimestamp": "",
         "state": "REJECTED",
-        "reason": "A User denied with the following message: The transaction was invalid.",
+        "reason": "The transaction was invalid.",
         "existingApprovals": {
           "users": [],
           "groups": []


### PR DESCRIPTION
### Reason for this PR
- Want to have the userRejectionMessage without an additional introductory string

### Changes in this PR
- Remove unnecessary string from return statement
