### PR TITLE
Add groups of user executing a transaction to approvals before valida…

### DIFF
--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/ContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/ContractUtil.java
@@ -1,5 +1,6 @@
 package de.upb.cs.uc4.chaincode.contract;
 
+import de.upb.cs.uc4.chaincode.contract.group.GroupContractUtil;
 import de.upb.cs.uc4.chaincode.contract.operation.OperationContractUtil;
 import de.upb.cs.uc4.chaincode.exceptions.*;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.ledgeraccess.LedgerStateNotFoundError;
@@ -134,7 +135,10 @@ abstract public class ContractUtil {
         } catch (Exception e) {
             approvals = new ApprovalList();
         }
-        approvals.addUsersItem(getEnrollmentIdFromClientId(ctx.getClientIdentity().getId()));
+        String clientId = getEnrollmentIdFromClientId(ctx.getClientIdentity().getId());
+        List<String> clientGroups = new GroupContractUtil().getGroupNamesForUser(ctx.getStub(), clientId);
+        approvals.addUsersItem(clientId);
+        approvals.addGroupsItems(clientGroups);
 
         if(!OperationContractUtil.covers(requiredApprovals, approvals)){
             throw new ValidationError(GsonWrapper.toJson(getInsufficientApprovalsError()));

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/MatriculationDataContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/MatriculationDataContractTest.java
@@ -82,12 +82,13 @@ public final class MatriculationDataContractTest extends TestCreationBase {
         return () -> {
             MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.MatriculationData:addMatriculationData");
             OperationContract operationContract = new OperationContract();
-            for (String id : ids) {
+            for (String id : ids.subList(1, ids.size())) {
                 Context ctx = TestUtil.mockContext(stub, id);
                 operationContract.approveTransaction(ctx, id, contract.contractName, "addMatriculationData", GsonWrapper.toJson(input));
 
             }
-            Context ctx = TestUtil.mockContext(stub);
+            // utilize one id here to test implicit approval by transaction execution
+            Context ctx = TestUtil.mockContext(stub, ids.get(0));
 
             String result = contract.addMatriculationData(ctx, input.get(0));
             assertThat(result).isEqualTo(compare.get(0));


### PR DESCRIPTION
### Reason for this PR
- the user executing a transaction should implicitly approve for its groups

### Changes in this PR
- consider user's groups when validating approvals
