### PR TITLE
Feature/pending check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [v0.16.4](https://github.com/upb-uc4/hyperledger_chaincode/compare/v0.16.3...v0.16.4) (2021-01-25)
+
+## Bugfix
+- transactions now check if the operation is pending before executing
+
 # [v0.16.3](https://github.com/upb-uc4/hyperledger_chaincode/compare/v0.16.2...v0.16.3) (2021-01-20)
 
 ## Feature

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/ContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/ContractUtil.java
@@ -101,7 +101,6 @@ abstract public class ContractUtil {
     }
 
     public GenericError getParamNumberError() {
-        // TODO add this error to operation api (approveTransaction)
         return new GenericError()
                 .type("HLParameterNumberError")
                 .title("The given number of parameters does not match the required number of parameters for the specified transaction");
@@ -133,7 +132,6 @@ abstract public class ContractUtil {
             throw new ValidationError(GsonWrapper.toJson(getInsufficientApprovalsError()));
         }
         ApprovalList approvals = operation.getExistingApprovals();
-        // TODO throw proper error for rejected operation (with reason)
         if(operation.getState() != OperationDataState.PENDING || !OperationContractUtil.covers(requiredApprovals, approvals)){
             throw new ValidationError(GsonWrapper.toJson(getInsufficientApprovalsError()));
         }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/ContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/ContractUtil.java
@@ -128,19 +128,22 @@ abstract public class ContractUtil {
         } catch (NoSuchAlgorithmException e) {
             throw new ValidationError(GsonWrapper.toJson(getInternalError()));
         }
-        OperationData operation;
+        ApprovalList approvals;
+        OperationDataState operationState;
         try{
-            operation = oUtil.getState(stub, key, OperationData.class);
+            OperationData operation = oUtil.getState(stub, key, OperationData.class);
+            approvals = operation.getExistingApprovals();
+            operationState = operation.getState();
         } catch (Exception e) {
-            throw new ValidationError(GsonWrapper.toJson(getInsufficientApprovalsError()));
+            approvals = new ApprovalList();
+            operationState = OperationDataState.PENDING;
         }
         String clientId = getEnrollmentIdFromClientId(ctx.getClientIdentity().getId());
         List<String> clientGroups = new GroupContractUtil().getGroupNamesForUser(ctx.getStub(), clientId);
-        ApprovalList approvals = operation.getExistingApprovals();
         approvals.addUsersItem(clientId);
         approvals.addGroupsItems(clientGroups);
 
-        if(operation.getState() != OperationDataState.PENDING || !OperationContractUtil.covers(requiredApprovals, approvals)){
+        if(operationState != OperationDataState.PENDING || !OperationContractUtil.covers(requiredApprovals, approvals)){
             throw new ValidationError(GsonWrapper.toJson(getInsufficientApprovalsError()));
         }
     }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/ContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/ContractUtil.java
@@ -120,20 +120,21 @@ abstract public class ContractUtil {
         }
 
         OperationContractUtil oUtil = new OperationContractUtil();
-        ApprovalList approvals;
         String key;
         try {
             key = OperationContractUtil.getDraftKey(contractName, transactionName, jsonArgs);
         } catch (NoSuchAlgorithmException e) {
             throw new ValidationError(GsonWrapper.toJson(getInternalError()));
         }
+        OperationData operation;
         try{
-            approvals = oUtil.getState(stub, key, OperationData.class).getExistingApprovals();
+            operation = oUtil.getState(stub, key, OperationData.class);
         } catch (Exception e) {
-            approvals = new ApprovalList();
+            throw new ValidationError(GsonWrapper.toJson(getInsufficientApprovalsError()));
         }
-
-        if(!OperationContractUtil.covers(requiredApprovals, approvals)){
+        ApprovalList approvals = operation.getExistingApprovals();
+        // TODO throw proper error for rejected operation (with reason)
+        if(operation.getState() != OperationDataState.PENDING || !OperationContractUtil.covers(requiredApprovals, approvals)){
             throw new ValidationError(GsonWrapper.toJson(getInsufficientApprovalsError()));
         }
     }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/OperationData.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/OperationData.java
@@ -122,6 +122,9 @@ public class OperationData {
     }
 
     public ApprovalList getExistingApprovals() {
+        if (existingApprovals == null) {
+            existingApprovals = new ApprovalList();
+        }
         return existingApprovals;
     }
 

--- a/UC4-chaincode/src/main/resources/project.properties
+++ b/UC4-chaincode/src/main/resources/project.properties
@@ -1,3 +1,3 @@
 #
-#Fri Jan 15 15:28:27 CET 2021
-rootVersion=0.15.1-15
+#Fri Jan 15 16:29:24 CET 2021
+rootVersion=0.15.2

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/OperationContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/OperationContractTest.java
@@ -189,9 +189,7 @@ public final class OperationContractTest extends TestCreationBase {
             Context ctx = TestUtil.mockContext(stub);
             MatriculationDataContract matriculationContract = new MatriculationDataContract();
             stub.setTxId(MatriculationDataContract.contractName + ":addMatriculationData");
-            System.out.println("########################################################################");
-            System.out.println(matriculationContract.addMatriculationData(ctx, input.get(0)));
-            System.out.println("########################################################################");
+            matriculationContract.addMatriculationData(ctx, input.get(0));
             String operationId = GsonWrapper.fromJson(operationJson, OperationData.class).getOperationId();
             stub.setTxId("UC4.OperationData:approveTransaction");
             OperationData operation = GsonWrapper.fromJson(contract.getOperationData(ctx, operationId), OperationData.class);

--- a/UC4-chaincode/src/test/resources/test_configs/matriculation_data_contract/AddMatriculationDataTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/matriculation_data_contract/AddMatriculationDataTestIO.json
@@ -548,5 +548,145 @@
         ]
       }
     ]
+  },
+  {
+    "name": "addFinishedOperationMatriculationData",
+    "type": "addMatriculationData_FAILURE",
+    "ids": [],
+    "setup": {
+      "operationContract": [
+        "mxRuZY52DtT0NcCIF9wXDO12JDAZVZTJIoqGr8SkI2A=",
+        {
+          "operationId": "mxRuZY52DtT0NcCIF9wXDO12JDAZVZTJIoqGr8SkI2A=",
+          "transactionInfo":
+          {
+            "contractName": "UC4.MatriculationData",
+            "transactionName":"addMatriculationData",
+            "parameters": "[\"{\\\"enrollmentId\\\":\\\"0000001\\\",\\\"matriculationStatus\\\":[{\\\"fieldOfStudy\\\":\\\"Computer Science\\\",\\\"semesters\\\":[\\\"WS2018/19\\\"]}]}\"]"
+          },
+          "initiator": "x509::CN=User1, OU=admin::CN=rca-org1, OU=UC4, O=UC4, L=Paderborn, ST=NRW, C=DE",
+          "initiatedTimestamp":"1970-01-01T00:00:00",
+          "lastModifiedTimestamp":"1970-01-01T00:00:00",
+          "state":"FINISHED",
+          "reason": "",
+          "existingApprovals":
+          {
+            "users": ["User1", "0000001"],
+            "groups": ["Admin"]
+          },
+          "missingApprovals":
+          {
+            "users": [],
+            "groups": []
+          }
+        }
+      ],
+      "examinationRegulationContract": [
+        "Computer Science",
+        {
+          "name": "Computer Science",
+          "active": true,
+          "modules": []
+        }
+      ],
+      "groupContract": [
+        "Admin",
+        {
+          "groupId": "Admin",
+          "userList": [
+            "User1"
+          ]
+        }
+      ]
+    },
+    "input": [
+      {
+        "enrollmentId": "0000001",
+        "matriculationStatus": [
+          {
+            "fieldOfStudy": "Computer Science",
+            "semesters": [
+              "WS2018/19"
+            ]
+          }
+        ]
+      }
+    ],
+    "compare": [
+      {
+        "type": "HLInsufficientApprovals",
+        "title": "The approvals present on the ledger do not suffice to execute this transaction"
+      }
+    ]
+  },
+  {
+    "name": "addRejectedOperationMatriculationData",
+    "type": "addMatriculationData_FAILURE",
+    "ids": [],
+    "setup": {
+      "operationContract": [
+        "mxRuZY52DtT0NcCIF9wXDO12JDAZVZTJIoqGr8SkI2A=",
+        {
+          "operationId": "mxRuZY52DtT0NcCIF9wXDO12JDAZVZTJIoqGr8SkI2A=",
+          "transactionInfo":
+          {
+            "contractName": "UC4.MatriculationData",
+            "transactionName":"addMatriculationData",
+            "parameters": "[\"{\\\"enrollmentId\\\":\\\"0000001\\\",\\\"matriculationStatus\\\":[{\\\"fieldOfStudy\\\":\\\"Computer Science\\\",\\\"semesters\\\":[\\\"WS2018/19\\\"]}]}\"]"
+          },
+          "initiator": "x509::CN=User1, OU=admin::CN=rca-org1, OU=UC4, O=UC4, L=Paderborn, ST=NRW, C=DE",
+          "initiatedTimestamp":"1970-01-01T00:00:00",
+          "lastModifiedTimestamp":"1970-01-01T00:00:00",
+          "state":"REJECTED",
+          "reason": "",
+          "existingApprovals":
+          {
+            "users": ["User1", "0000001"],
+            "groups": ["Admin"]
+          },
+          "missingApprovals":
+          {
+            "users": [],
+            "groups": []
+          }
+        }
+      ],
+      "examinationRegulationContract": [
+        "Computer Science",
+        {
+          "name": "Computer Science",
+          "active": true,
+          "modules": []
+        }
+      ],
+      "groupContract": [
+        "Admin",
+        {
+          "groupId": "Admin",
+          "userList": [
+            "User1"
+          ]
+        }
+      ]
+    },
+    "input": [
+      {
+        "enrollmentId": "0000001",
+        "matriculationStatus": [
+          {
+            "fieldOfStudy": "Computer Science",
+            "semesters": [
+              "WS2018/19"
+            ]
+          }
+        ]
+      }
+    ],
+    "compare": [
+      {
+        "type": "HLInsufficientApprovals",
+        "title": "The approvals present on the ledger do not suffice to execute this transaction"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### Reason for this PR
- transactions requiring approvals should only be executable if the corresponding operation is still pending

### Changes in this PR
- check if an operation is pending before executing a transaction
