### PR TITLE
Remove access rights from certificate transactions

### DIFF
--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/AccessManager.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/AccessManager.java
@@ -202,13 +202,13 @@ public class AccessManager {
     }
 
     private static ApprovalList getRequiredApprovalsForUpdateCertificate(Context ctx, List<String> params) {
-        return new ApprovalList()
-                .addGroupsItem(SYSTEM);
+        // TODO fill with required approvals
+        return new ApprovalList();
     }
 
     private static ApprovalList getRequiredApprovalsForGetCertificate(Context ctx, List<String> params) {
-        return new ApprovalList()
-                .addGroupsItem(SYSTEM);
+        // TODO fill with required approvals
+        return new ApprovalList();
     }
 
     private static ApprovalList getRequiredApprovalsForAddExaminationRegulation(Context ctx, List<String> params) {


### PR DESCRIPTION
### Reason for this PR
- add or update certificate in hlf-api repo fails, if the system group was not set before

### Changes in this PR
- remove system group from required apporvals of certificate transactions
