### PR TITLE
Replace transaction names by variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [v0.16.9](https://github.com/upb-uc4/hyperledger_chaincode/compare/v0.16.8...v0.16.9) (2021-01-29)
+# [v0.17.0](https://github.com/upb-uc4/hyperledger_chaincode/compare/v0.16.8...v0.17.0) (2021-01-29)
 
 ## Bugfix
 - operationIds now no longer contain "=" signs

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/ContractBase.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/ContractBase.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 
 public abstract class ContractBase implements ContractInterface {
     protected String contractName = "UC4.ContractBase";
+    public final static String transactionNameGetVersion = "getVersion";
 
     /**
      * Gets version of the chaincode

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContract.java
@@ -22,6 +22,9 @@ public class AdmissionContract extends ContractBase {
     private final AdmissionContractUtil cUtil = new AdmissionContractUtil();
 
     public final static String contractName = "UC4.Admission";
+    public final static String transactionNameAddAdmission = "addAdmission";
+    public final static String transactionNameDropAdmission = "dropAdmission";
+    public final static String transactionNameGetAdmissions = "getAdmissions";
 
     /**
      * Adds MatriculationData to the ledger.

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/certificate/CertificateContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/certificate/CertificateContract.java
@@ -20,6 +20,9 @@ public class CertificateContract extends ContractBase {
     private final CertificateContractUtil cUtil = new CertificateContractUtil();
 
     public final static String contractName = "UC4.Certificate";
+    public final static String transactionNameAddCertificate = "addCertificate";
+    public final static String transactionNameGetCertificate = "getCertificate";
+    public final static String transactionNameUpdateCertificate = "updateCertificate";
 
     /**
      * Adds a certificate to the ledger.

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examinationregulation/ExaminationRegulationContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examinationregulation/ExaminationRegulationContract.java
@@ -25,6 +25,9 @@ public class ExaminationRegulationContract extends ContractBase {
 
     private final ExaminationRegulationContractUtil cUtil = new ExaminationRegulationContractUtil();
     public final static String contractName = "UC4.ExaminationRegulation";
+    public final static String transactionNameAddExaminationRegulation = "addExaminationRegulation";
+    public final static String transactionNameGetExaminationRegulations = "getExaminationRegulations";
+    public final static String transactionNameCloseExaminationRegulation = "closeExaminationRegulation";
 
     /**
      * Adds an examination regulation to the ledger.

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/group/GroupContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/group/GroupContract.java
@@ -23,6 +23,12 @@ public class GroupContract extends ContractBase {
     private final GroupContractUtil cUtil = new GroupContractUtil();
 
     public final static String contractName = "UC4.Group";
+    public final static String transactionNameAddUserToGroup = "addUserToGroup";
+    public final static String transactionNameRemoveUserFromGroup = "removeUserFromGroup";
+    public final static String transactionNameRemoveUserFromAllGroups = "removeUserFromAllGroups";
+    public final static String transactionNameGetAllGroups = "getAllGroups";
+    public final static String transactionNameGetUsersForGroup = "getUsersForGroup";
+    public final static String transactionNameGetGroupsForUser = "getGroupsForUser";
 
     /**
      * Adds user to group.

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/matriculationdata/MatriculationDataContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/matriculationdata/MatriculationDataContract.java
@@ -25,6 +25,10 @@ public class MatriculationDataContract extends ContractBase {
     private final MatriculationDataContractUtil cUtil = new MatriculationDataContractUtil();
 
     public final static String contractName = "UC4.MatriculationData";
+    public final static String transactionNameAddMatriculationData = "addMatriculationData";
+    public final static String transactionNameUpdateMatriculationData = "updateMatriculationData";
+    public final static String transactionNameGetMatriculationData = "getMatriculationData";
+    public final static String transactionNameAddEntriesToMatriculationData = "addEntriesToMatriculationData";
 
     /**
      * Adds MatriculationData to the ledger.

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/operation/OperationContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/operation/OperationContract.java
@@ -2,13 +2,10 @@ package de.upb.cs.uc4.chaincode.contract.operation;
 
 import com.google.common.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.ContractBase;
-import de.upb.cs.uc4.chaincode.contract.group.GroupContractUtil;
 import de.upb.cs.uc4.chaincode.exceptions.SerializableError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.LedgerAccessError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.ParameterError;
-import de.upb.cs.uc4.chaincode.exceptions.serializable.parameter.MissingTransactionError;
 import de.upb.cs.uc4.chaincode.helper.GsonWrapper;
-import de.upb.cs.uc4.chaincode.helper.HyperledgerManager;
 import de.upb.cs.uc4.chaincode.helper.ValidationManager;
 import de.upb.cs.uc4.chaincode.model.*;
 import org.hyperledger.fabric.contract.Context;
@@ -21,11 +18,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Contract(
-        name = "UC4.OperationData"
+        name = OperationContract.contractName
 )
 public class OperationContract extends ContractBase {
 
     private final OperationContractUtil cUtil = new OperationContractUtil();
+
+    public final static String contractName = "UC4.OperationData";
+    public final static String transactionNameInitiateOperation = "initiateOperation";
+    public final static String transactionNameApproveOperation = "approveOperation";
+    public final static String transactionNameRejectOperation = "rejectOperation";
+    public final static String transactionNameGetOperations = "getOperations";
 
     /**
      * Submits a draft to the ledger.

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/AccessManager.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/AccessManager.java
@@ -32,15 +32,15 @@ public class AccessManager {
         switch (contractName) {
             case MatriculationDataContract.contractName:
                 switch (transactionName) {
-                    case "addMatriculationData":
+                    case MatriculationDataContract.transactionNameAddMatriculationData:
                         return getRequiredApprovalsForAddMatriculationData(ctx, paramList);
-                    case "updateMatriculationData":
+                    case MatriculationDataContract.transactionNameUpdateMatriculationData:
                         return getRequiredApprovalsForUpdateMatriculationData(ctx, paramList);
-                    case "getMatriculationData":
+                    case MatriculationDataContract.transactionNameGetMatriculationData:
                         return getRequiredApprovalsForGetMatriculationData(ctx, paramList);
-                    case "addEntriesToMatriculationData":
+                    case MatriculationDataContract.transactionNameAddEntriesToMatriculationData:
                         return getRequiredApprovalsForAddEntriesToMatriculationData(ctx, paramList);
-                    case "getVersion":
+                    case MatriculationDataContract.transactionNameGetVersion:
                         return new ApprovalList();
                     case "":
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getEmptyTransactionNameError()));
@@ -49,13 +49,13 @@ public class AccessManager {
                 }
             case AdmissionContract.contractName:
                 switch (transactionName) {
-                    case "addAdmission":
+                    case AdmissionContract.transactionNameAddAdmission:
                         return getRequiredApprovalsForAddAdmission(ctx, paramList);
-                    case "dropAdmission":
+                    case AdmissionContract.transactionNameDropAdmission:
                         return getRequiredApprovalsForDropAdmission(ctx, paramList);
-                    case "getAdmissions":
+                    case AdmissionContract.transactionNameGetAdmissions:
                         return getRequiredApprovalsForGetAdmissions(ctx, paramList);
-                    case "getVersion":
+                    case AdmissionContract.transactionNameGetVersion:
                         return new ApprovalList();
                     case "":
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getEmptyTransactionNameError()));
@@ -64,19 +64,19 @@ public class AccessManager {
                 }
             case GroupContract.contractName:
                 switch (transactionName) {
-                    case "addUserToGroup":
+                    case GroupContract.transactionNameAddUserToGroup:
                         return getRequiredApprovalsForAddUserToGroup(ctx, paramList);
-                    case "removeUserFromGroup":
+                    case GroupContract.transactionNameRemoveUserFromGroup:
                         return getRequiredApprovalsForRemoveUserFromGroup(ctx, paramList);
-                    case "removeUserFromAllGroups":
+                    case GroupContract.transactionNameRemoveUserFromAllGroups:
                         return getRequiredApprovalsForRemoveUserFromAllGroups(ctx, paramList);
-                    case "getAllGroups":
+                    case GroupContract.transactionNameGetAllGroups:
                         return getRequiredApprovalsForGetAllGroups(ctx, paramList);
-                    case "getUsersForGroup":
+                    case GroupContract.transactionNameGetUsersForGroup:
                         return getRequiredApprovalsForGetUsersForGroup(ctx, paramList);
-                    case "getGroupsForUser":
+                    case GroupContract.transactionNameGetGroupsForUser:
                         return getRequiredApprovalsForGetGroupsForUser(ctx, paramList);
-                    case "getVersion":
+                    case GroupContract.transactionNameGetVersion:
                         return new ApprovalList();
                     case "":
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getEmptyTransactionNameError()));
@@ -85,13 +85,13 @@ public class AccessManager {
                 }
             case CertificateContract.contractName:
                 switch (transactionName) {
-                    case "addCertificate":
+                    case CertificateContract.transactionNameAddCertificate:
                         return getRequiredApprovalsForAddCertificate(ctx, paramList);
-                    case "updateCertificate":
+                    case CertificateContract.transactionNameUpdateCertificate:
                         return getRequiredApprovalsForUpdateCertificate(ctx, paramList);
-                    case "getCertificate":
+                    case CertificateContract.transactionNameGetCertificate:
                         return getRequiredApprovalsForGetCertificate(ctx, paramList);
-                    case "getVersion":
+                    case CertificateContract.transactionNameGetVersion:
                         return new ApprovalList();
                     case "":
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getEmptyTransactionNameError()));
@@ -100,13 +100,13 @@ public class AccessManager {
                 }
             case ExaminationRegulationContract.contractName:
                 switch (transactionName) {
-                    case "addExaminationRegulation":
+                    case ExaminationRegulationContract.transactionNameAddExaminationRegulation:
                         return getRequiredApprovalsForAddExaminationRegulation(ctx, paramList);
-                    case "getExaminationRegulations":
+                    case ExaminationRegulationContract.transactionNameGetExaminationRegulations:
                         return getRequiredApprovalsForGetExaminationRegulations(ctx, paramList);
-                    case "closeExaminationRegulation":
+                    case ExaminationRegulationContract.transactionNameCloseExaminationRegulation:
                         return getRequiredApprovalsForCloseExaminationRegulation(ctx, paramList);
-                    case "getVersion":
+                    case ExaminationRegulationContract.transactionNameGetVersion:
                         return new ApprovalList();
                     case "":
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getEmptyTransactionNameError()));

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/ValidationManager.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/ValidationManager.java
@@ -35,19 +35,19 @@ public class ValidationManager {
         switch (contractName) {
             case MatriculationDataContract.contractName:
                 switch (transactionName) {
-                    case "addMatriculationData":
+                    case MatriculationDataContract.transactionNameAddMatriculationData:
                         matriculationDataUtil.checkParamsAddMatriculationData(ctx, paramList);
                         break;
-                    case "updateMatriculationData":
+                    case MatriculationDataContract.transactionNameUpdateMatriculationData:
                         matriculationDataUtil.checkParamsUpdateMatriculationData(ctx, paramList);
                         break;
-                    case "getMatriculationData":
+                    case MatriculationDataContract.transactionNameGetMatriculationData:
                         matriculationDataUtil.checkParamsGetMatriculationData(ctx, paramList);
                         break;
-                    case "addEntriesToMatriculationData":
+                    case MatriculationDataContract.transactionNameAddEntriesToMatriculationData:
                         matriculationDataUtil.checkParamsAddEntriesToMatriculationData(ctx, paramList);
                         break;
-                    case "getVersion":
+                    case MatriculationDataContract.transactionNameGetVersion:
                         break;
                     case "":
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getEmptyTransactionNameError()));
@@ -57,16 +57,16 @@ public class ValidationManager {
                 break;
             case AdmissionContract.contractName:
                 switch (transactionName) {
-                    case "addAdmission":
+                    case AdmissionContract.transactionNameAddAdmission:
                         admissionUtil.checkParamsAddAdmission(ctx, paramList);
                         break;
-                    case "dropAdmission":
+                    case AdmissionContract.transactionNameDropAdmission:
                         admissionUtil.checkParamsDropAdmission(ctx, paramList);
                         break;
-                    case "getAdmissions":
+                    case AdmissionContract.transactionNameGetAdmissions:
                         // pass
                         break;
-                    case "getVersion":
+                    case AdmissionContract.transactionNameGetVersion:
                         break;
                     case "":
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getEmptyTransactionNameError()));
@@ -76,25 +76,25 @@ public class ValidationManager {
                 break;
             case GroupContract.contractName:
                 switch (transactionName) {
-                    case "addUserToGroup":
+                    case GroupContract.transactionNameAddUserToGroup:
                         groupUtil.checkParamsAddUserToGroup(ctx, paramList);
                         break;
-                    case "removeUserFromGroup":
+                    case GroupContract.transactionNameRemoveUserFromGroup:
                         groupUtil.checkParamsRemoveUserFromGroup(ctx, paramList);
                         break;
-                    case "removeUserFromAllGroups":
+                    case GroupContract.transactionNameRemoveUserFromAllGroups:
                         groupUtil.checkParamsRemoveUserFromAllGroups(paramList);
                         break;
-                    case "getAllGroups":
+                    case GroupContract.transactionNameGetAllGroups:
                         // pass, for there are no parameters
                         break;
-                    case "getUsersForGroup":
+                    case GroupContract.transactionNameGetUsersForGroup:
                         groupUtil.checkParamsGetUsersForGroup(ctx, paramList);
                         break;
-                    case "getGroupsForUser":
+                    case GroupContract.transactionNameGetGroupsForUser:
                         groupUtil.checkParamsGetGroupsForUser(paramList);
                         break;
-                    case "getVersion":
+                    case GroupContract.transactionNameGetVersion:
                         break;
                     case "":
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getEmptyTransactionNameError()));
@@ -104,16 +104,16 @@ public class ValidationManager {
                 break;
             case ExaminationRegulationContract.contractName:
                 switch (transactionName) {
-                    case "addExaminationRegulation":
+                    case ExaminationRegulationContract.transactionNameAddExaminationRegulation:
                         examinationRegulationUtil.checkParamsAddExaminationRegulation(ctx, paramList);
                         break;
-                    case "getExaminationRegulations":
+                    case ExaminationRegulationContract.transactionNameGetExaminationRegulations:
                         examinationRegulationUtil.checkParamsGetExaminationRegulations(paramList);
                         break;
-                    case "closeExaminationRegulation":
+                    case ExaminationRegulationContract.transactionNameCloseExaminationRegulation:
                         examinationRegulationUtil.checkParamsCloseExaminationRegulation(ctx, paramList);
                         break;
-                    case "getVersion":
+                    case ExaminationRegulationContract.transactionNameGetVersion:
                         break;
                     case "":
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getEmptyTransactionNameError()));
@@ -123,16 +123,16 @@ public class ValidationManager {
                 break;
             case CertificateContract.contractName:
                 switch (transactionName) {
-                    case "addCertificate":
+                    case CertificateContract.transactionNameAddCertificate:
                         certificateUtil.checkParamsAddCertificate(ctx, paramList);
                         break;
-                    case "updateCertificate":
+                    case CertificateContract.transactionNameUpdateCertificate:
                         certificateUtil.checkParamsUpdateCertificate(ctx, paramList);
                         break;
-                    case "getCertificate":
+                    case CertificateContract.transactionNameGetCertificate:
                         certificateUtil.checkParamsGetCertificate(ctx, paramList);
                         break;
-                    case "getVersion":
+                    case CertificateContract.transactionNameGetVersion:
                         break;
                     case "":
                         throw new MissingTransactionError(GsonWrapper.toJson(operationUtil.getEmptyTransactionNameError()));

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/AdmissionContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/AdmissionContractTest.java
@@ -56,14 +56,13 @@ public final class AdmissionContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Admission:addAdmission");
-            TestUtil.approveOperation(stub, AdmissionContract.contractName, "addAdmission", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
-            String addResult = contract.addAdmission(ctx, input.get(0));
-            assertThat(addResult).isEqualTo(compare.get(0));
+            Context ctx = TestUtil.buildContext(AdmissionContract.contractName, AdmissionContract.transactionNameAddAdmission, setup, input, ids);
 
+            String addResult = contract.addAdmission(ctx, input.get(0));
+
+            assertThat(addResult).isEqualTo(compare.get(0));
             Admission compareAdmission = GsonWrapper.fromJson(compare.get(0), Admission.class);
-            Admission ledgerAdmission = cUtil.getState(stub, compareAdmission.getAdmissionId(), Admission.class);
+            Admission ledgerAdmission = cUtil.getState(ctx.getStub(), compareAdmission.getAdmissionId(), Admission.class);
             assertThat(ledgerAdmission).isEqualTo(compareAdmission);
             assertThat(ledgerAdmission.toString()).isEqualTo(compareAdmission.toString());
         };
@@ -76,9 +75,7 @@ public final class AdmissionContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Admission:addAdmission");
-            TestUtil.approveOperation(stub, AdmissionContract.contractName, "addAdmission", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(AdmissionContract.contractName, AdmissionContract.transactionNameAddAdmission, setup, input, ids);
             String result = contract.addAdmission(ctx, input.get(0));
             assertThat(result).isEqualTo(compare.get(0));
         };
@@ -91,14 +88,12 @@ public final class AdmissionContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Admission:dropAdmission");
-            TestUtil.approveOperation(stub, AdmissionContract.contractName, "dropAdmission", ids, input);
+            Context ctx = TestUtil.buildContext(AdmissionContract.contractName, AdmissionContract.transactionNameDropAdmission, setup, input, ids);
 
-            Context ctx = TestUtil.mockContext(stub);
             String dropResult = contract.dropAdmission(ctx, input.get(0));
-            assertThat(dropResult).isEqualTo(compare.get(0));
 
-            List<Admission> ledgerState = cUtil.getAllStates(stub, Admission.class);
+            assertThat(dropResult).isEqualTo(compare.get(0));
+            List<Admission> ledgerState = cUtil.getAllStates(ctx.getStub(), Admission.class);
             assertThat(ledgerState).allMatch(item -> !(item.getAdmissionId().equals(input.get(0))));
         };
     }
@@ -110,9 +105,8 @@ public final class AdmissionContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Admission:dropAdmission");
-            TestUtil.approveOperation(stub, AdmissionContract.contractName, "dropAdmission", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(AdmissionContract.contractName, AdmissionContract.transactionNameDropAdmission, setup, input, ids);
+
             String result = contract.dropAdmission(ctx, input.get(0));
             assertThat(result).isEqualTo(compare.get(0));
         };
@@ -125,9 +119,8 @@ public final class AdmissionContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Admission:getAdmissions");
-            TestUtil.approveOperation(stub, AdmissionContract.contractName, "getAdmissions", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(AdmissionContract.contractName, AdmissionContract.transactionNameGetAdmissions, setup, input, ids);
+
             String getResult = contract.getAdmissions(ctx, input.get(0), input.get(1), input.get(2));
             assertThat(getResult).isEqualTo(compare.get(0));
         };

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/CertificateContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/CertificateContractTest.java
@@ -48,11 +48,11 @@ public final class CertificateContractTest extends TestCreationBase {
             case "addCertificate_SUCCESS":
                 return DynamicTest.dynamicTest(testName, addCertificateSuccessTest(setup, input, compare, ids));
             case "addCertificate_FAILURE":
-                return DynamicTest.dynamicTest(testName, addCertificateFailureTest(setup, input, compare));
+                return DynamicTest.dynamicTest(testName, addCertificateFailureTest(setup, input, compare, ids));
             case "updateCertificate_SUCCESS":
                 return DynamicTest.dynamicTest(testName, updateCertificateSuccessTest(setup, input, compare, ids));
             case "updateCertificate_FAILURE":
-                return DynamicTest.dynamicTest(testName, updateCertificateFailureTest(setup, input, compare));
+                return DynamicTest.dynamicTest(testName, updateCertificateFailureTest(setup, input, compare, ids));
             default:
                 throw new RuntimeException("Test " + testName + " of type " + testType + " could not be matched.");
         }
@@ -65,9 +65,7 @@ public final class CertificateContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Certificate:getCertificate");
-            TestUtil.approveOperation(stub, CertificateContract.contractName, "getCertificate", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(CertificateContract.contractName, CertificateContract.transactionNameGetCertificate, setup, input, ids);
 
             String certificate = contract.getCertificate(ctx, input.get(0));
             assertThat(certificate).isEqualTo(compare.get(0));
@@ -81,9 +79,7 @@ public final class CertificateContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Certificate:addCertificate");
-            TestUtil.approveOperation(stub, CertificateContract.contractName, "addCertificate", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(CertificateContract.contractName, CertificateContract.transactionNameAddCertificate, setup, input, ids);
 
             assertThat(contract.addCertificate(ctx, input.get(0), input.get(1)))
                     .isEqualTo(compare.get(0));
@@ -95,11 +91,11 @@ public final class CertificateContractTest extends TestCreationBase {
     private Executable addCertificateFailureTest(
             JsonIOTestSetup setup,
             List<String> input,
-            List<String> compare
+            List<String> compare,
+            List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Certificate:addCertificate");
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(CertificateContract.contractName, CertificateContract.transactionNameAddCertificate, setup, input, ids);
 
             String result = contract.addCertificate(ctx, input.get(0), input.get(1));
             assertThat(result).isEqualTo(compare.get(0));
@@ -113,9 +109,7 @@ public final class CertificateContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Certificate:updateCertificate");
-            TestUtil.approveOperation(stub, CertificateContract.contractName, "updateCertificate", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(CertificateContract.contractName, CertificateContract.transactionNameUpdateCertificate, setup, input, ids);
 
             assertThat(contract.updateCertificate(ctx, input.get(0), input.get(1)))
                     .isEqualTo(compare.get(0));
@@ -128,11 +122,11 @@ public final class CertificateContractTest extends TestCreationBase {
     private Executable updateCertificateFailureTest(
             JsonIOTestSetup setup,
             List<String> input,
-            List<String> compare
+            List<String> compare,
+            List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Certificate:updateCertificate");
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(CertificateContract.contractName, CertificateContract.transactionNameUpdateCertificate, setup, input, ids);
 
             String result = contract.updateCertificate(ctx, input.get(0), input.get(1));
             assertThat(result).isEqualTo(compare.get(0));

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/ExaminationRegulationContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/ExaminationRegulationContractTest.java
@@ -1,6 +1,7 @@
 package de.upb.cs.uc4.chaincode;
 
 
+import de.upb.cs.uc4.chaincode.contract.certificate.CertificateContract;
 import de.upb.cs.uc4.chaincode.contract.examinationregulation.ExaminationRegulationContract;
 import de.upb.cs.uc4.chaincode.mock.MockChaincodeStub;
 import de.upb.cs.uc4.chaincode.model.ExaminationRegulation;
@@ -40,11 +41,11 @@ public final class ExaminationRegulationContractTest extends TestCreationBase {
             case "addExaminationRegulation_SUCCESS":
                 return DynamicTest.dynamicTest(testName, addExaminationRegulationSuccessTest(setup, input, compare, ids));
             case "addExaminationRegulation_FAILURE":
-                return DynamicTest.dynamicTest(testName, addExaminationRegulationFailureTest(setup, input, compare));
+                return DynamicTest.dynamicTest(testName, addExaminationRegulationFailureTest(setup, input, compare, ids));
             case "closeExaminationRegulation_SUCCESS":
                 return DynamicTest.dynamicTest(testName, closeExaminationRegulationSuccessTest(setup, input, compare, ids));
             case "closeExaminationRegulation_FAILURE":
-                return DynamicTest.dynamicTest(testName, closeExaminationRegulationFailureTest(setup, input, compare));
+                return DynamicTest.dynamicTest(testName, closeExaminationRegulationFailureTest(setup, input, compare, ids));
             default:
                 throw new RuntimeException("Test " + testName + " of type " + testType + " could not be matched.");
         }
@@ -57,9 +58,7 @@ public final class ExaminationRegulationContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.ExaminationRegulation:getExaminationRegulations");
-            TestUtil.approveOperation(stub, ExaminationRegulationContract.contractName,"getExaminationRegulations", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(ExaminationRegulationContract.contractName, ExaminationRegulationContract.transactionNameGetExaminationRegulations, setup, input, ids);
 
             String regulations = contract.getExaminationRegulations(ctx, input.get(0));
             assertThat(regulations).isEqualTo(compare.get(0));
@@ -73,9 +72,7 @@ public final class ExaminationRegulationContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.ExaminationRegulation:addExaminationRegulation");
-            TestUtil.approveOperation(stub, ExaminationRegulationContract.contractName,"addExaminationRegulation", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(ExaminationRegulationContract.contractName, ExaminationRegulationContract.transactionNameAddExaminationRegulation, setup, input, ids);
 
             String result = contract.addExaminationRegulation(ctx, input.get(0));
             assertThat(result).isEqualTo(compare.get(0));
@@ -90,11 +87,11 @@ public final class ExaminationRegulationContractTest extends TestCreationBase {
     private Executable addExaminationRegulationFailureTest(
             JsonIOTestSetup setup,
             List<String> input,
-            List<String> compare
+            List<String> compare,
+            List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.ExaminationRegulation:addExaminationRegulation");
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(ExaminationRegulationContract.contractName, ExaminationRegulationContract.transactionNameAddExaminationRegulation, setup, input, ids);
 
             String result = contract.addExaminationRegulation(ctx, input.get(0));
             assertThat(result).isEqualTo(compare.get(0));
@@ -108,9 +105,7 @@ public final class ExaminationRegulationContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.ExaminationRegulation:closeExaminationRegulation");
-            TestUtil.approveOperation(stub, ExaminationRegulationContract.contractName,"closeExaminationRegulation", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(ExaminationRegulationContract.contractName, ExaminationRegulationContract.transactionNameCloseExaminationRegulation, setup, input, ids);
 
             String result = contract.closeExaminationRegulation(ctx, input.get(0));
             assertThat(result).isEqualTo(compare.get(0));
@@ -125,11 +120,11 @@ public final class ExaminationRegulationContractTest extends TestCreationBase {
     private Executable closeExaminationRegulationFailureTest(
             JsonIOTestSetup setup,
             List<String> input,
-            List<String> compare
+            List<String> compare,
+            List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.ExaminationRegulation:closeExaminationRegulation");
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(ExaminationRegulationContract.contractName, ExaminationRegulationContract.transactionNameCloseExaminationRegulation, setup, input, ids);
 
             String result = contract.closeExaminationRegulation(ctx, input.get(0));
             assertThat(result).isEqualTo(compare.get(0));

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/GroupContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/GroupContractTest.java
@@ -1,6 +1,7 @@
 package de.upb.cs.uc4.chaincode;
 
 import de.upb.cs.uc4.chaincode.contract.certificate.CertificateContract;
+import de.upb.cs.uc4.chaincode.contract.examinationregulation.ExaminationRegulationContract;
 import de.upb.cs.uc4.chaincode.contract.group.GroupContract;
 import de.upb.cs.uc4.chaincode.contract.operation.OperationContract;
 import de.upb.cs.uc4.chaincode.mock.MockChaincodeStub;
@@ -69,14 +70,13 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:addUserToGroup");
-            TestUtil.approveOperation(stub, GroupContract.contractName,"addUserToGroup", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(GroupContract.contractName, GroupContract.transactionNameAddUserToGroup, setup, input, ids);
+
             String addResult = contract.addUserToGroup(ctx, input.get(0), input.get(1));
             assertThat(addResult).isEqualTo("");
 
             Group compareGroup = GsonWrapper.fromJson(compare.get(0), Group.class);
-            Group ledgerGroup = cUtil.getState(stub, compareGroup.getGroupId(), Group.class);
+            Group ledgerGroup = cUtil.getState(ctx.getStub(), compareGroup.getGroupId(), Group.class);
             assertThat(ledgerGroup).isEqualTo(compareGroup);
             assertThat(ledgerGroup.toString()).isEqualTo(compareGroup.toString());
         };
@@ -89,9 +89,8 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:addUserToGroup");
-            TestUtil.approveOperation(stub, GroupContract.contractName,"addUserToGroup", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(GroupContract.contractName, GroupContract.transactionNameAddUserToGroup, setup, input, ids);
+
             String result = contract.addUserToGroup(ctx, input.get(0), input.get(1));
             DetailedError actualError = GsonWrapper.fromJson(result, DetailedError.class);
             DetailedError expectedError = GsonWrapper.fromJson(compare.get(0), DetailedError.class);
@@ -106,15 +105,14 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:removeUserFromGroup");
-            TestUtil.approveOperation(stub, GroupContract.contractName,"removeUserFromGroup", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(GroupContract.contractName, GroupContract.transactionNameRemoveUserFromGroup, setup, input, ids);
+
             String dropResult = contract.removeUserFromGroup(ctx, input.get(0), input.get(1));
             assertThat(dropResult).isEqualTo("");
 
             for (String i : compare) {
                 Group compareGroup = GsonWrapper.fromJson(i, Group.class);
-                Group ledgerGroup = cUtil.getState(stub, compareGroup.getGroupId(), Group.class);
+                Group ledgerGroup = cUtil.getState(ctx.getStub(), compareGroup.getGroupId(), Group.class);
                 assertThat(ledgerGroup).isEqualTo(compareGroup);
             }
 
@@ -129,9 +127,8 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:removeUserFromGroup");
-            TestUtil.approveOperation(stub, GroupContract.contractName,"removeUserFromGroup", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(GroupContract.contractName, GroupContract.transactionNameRemoveUserFromGroup, setup, input, ids);
+
             String result = contract.removeUserFromGroup(ctx, input.get(0), input.get(1));
             assertThat(result).isEqualTo(compare.get(0));
         };
@@ -145,15 +142,14 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:removeUserFromAllGroups");
-            TestUtil.approveOperation(stub, GroupContract.contractName,"removeUserFromAllGroups", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(GroupContract.contractName, GroupContract.transactionNameRemoveUserFromAllGroups, setup, input, ids);
+
             String dropResult = contract.removeUserFromAllGroups(ctx, input.get(0));
             assertThat(dropResult).isEqualTo("");
 
             for (String i : compare) {
                 Group compareGroup = GsonWrapper.fromJson(i, Group.class);
-                Group ledgerGroup = cUtil.getState(stub, compareGroup.getGroupId(), Group.class);
+                Group ledgerGroup = cUtil.getState(ctx.getStub(), compareGroup.getGroupId(), Group.class);
                 assertThat(ledgerGroup).isEqualTo(compareGroup);
             }
 
@@ -168,9 +164,8 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:removeUserFromAllGroups");
-            TestUtil.approveOperation(stub, GroupContract.contractName,"removeUserFromAllGroups", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(GroupContract.contractName, GroupContract.transactionNameRemoveUserFromAllGroups, setup, input, ids);
+
             String result = contract.removeUserFromAllGroups(ctx, input.get(0));
             DetailedError actualError = GsonWrapper.fromJson(result, DetailedError.class);
             DetailedError expectedError = GsonWrapper.fromJson(compare.get(0), DetailedError.class);
@@ -186,9 +181,8 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:getAllGroups");
-            TestUtil.approveOperation(stub, GroupContract.contractName,"getAllGroups", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(GroupContract.contractName, GroupContract.transactionNameGetAllGroups, setup, input, ids);
+
             String dropResult = contract.getAllGroups(ctx);
             assertThat(dropResult).isEqualTo(compare.get(0));
 
@@ -202,9 +196,8 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:getUsersForGroup");
-            TestUtil.approveOperation(stub, GroupContract.contractName,"getUsersForGroup", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(GroupContract.contractName, GroupContract.transactionNameGetUsersForGroup, setup, input, ids);
+
             String dropResult = contract.getUsersForGroup(ctx, input.get(0));
             assertThat(dropResult).isEqualTo(compare.get(0));
 
@@ -218,9 +211,8 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:getUsersForGroup");
-            TestUtil.approveOperation(stub, GroupContract.contractName,"getUsersForGroup", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(GroupContract.contractName, GroupContract.transactionNameGetUsersForGroup, setup, input, ids);
+
             String result = contract.getUsersForGroup(ctx, input.get(0));
             assertThat(result).isEqualTo(compare.get(0));
         };
@@ -233,9 +225,8 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:getGroupsForUser");
-            TestUtil.approveOperation(stub, GroupContract.contractName,"getGroupsForUser", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(GroupContract.contractName, GroupContract.transactionNameGetGroupsForUser, setup, input, ids);
+
             String dropResult = contract.getGroupsForUser(ctx, input.get(0));
             assertThat(dropResult).isEqualTo(compare.get(0));
 
@@ -249,9 +240,7 @@ public final class GroupContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.Group:getGroupsForUser");
-            TestUtil.approveOperation(stub, GroupContract.contractName,"getGroupsForUser", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(GroupContract.contractName, GroupContract.transactionNameGetGroupsForUser, setup, input, ids);
             String result = contract.getGroupsForUser(ctx, input.get(0));
             DetailedError actualError = GsonWrapper.fromJson(result, DetailedError.class);
             DetailedError expectedError = GsonWrapper.fromJson(compare.get(0), DetailedError.class);

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/MatriculationDataContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/MatriculationDataContractTest.java
@@ -48,11 +48,11 @@ public final class MatriculationDataContractTest extends TestCreationBase {
             case "updateMatriculationData_SUCCESS":
                 return DynamicTest.dynamicTest(testName, updateMatriculationDataSuccessTest(setup, input, compare, ids));
             case "updateMatriculationData_FAILURE":
-                return DynamicTest.dynamicTest(testName, updateMatriculationDataFailureTest(setup, input, compare));
+                return DynamicTest.dynamicTest(testName, updateMatriculationDataFailureTest(setup, input, compare, ids));
             case "addEntriesToMatriculationData_SUCCESS":
                 return DynamicTest.dynamicTest(testName, addEntriesToMatriculationDataSuccessTest(setup, input, compare, ids));
             case "addEntriesToMatriculationData_FAILURE":
-                return DynamicTest.dynamicTest(testName, addEntriesToMatriculationDataFailureTest(setup, input, compare));
+                return DynamicTest.dynamicTest(testName, addEntriesToMatriculationDataFailureTest(setup, input, compare, ids));
             default:
                 throw new RuntimeException("Test " + testName + " of type " + testType + " could not be matched.");
         }
@@ -65,9 +65,7 @@ public final class MatriculationDataContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.MatriculationData:getMatriculationData");
-            TestUtil.approveOperation(stub, MatriculationDataContract.contractName,"getMatriculationData", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(MatriculationDataContract.contractName, MatriculationDataContract.transactionNameGetMatriculationData, setup, input, ids);
 
             MatriculationData compareMatriculationData = GsonWrapper.fromJson(compare.get(0), MatriculationData.class);
             MatriculationData ledgerMatriculationData = GsonWrapper.fromJson(
@@ -83,10 +81,7 @@ public final class MatriculationDataContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.MatriculationData:addMatriculationData");
-            TestUtil.approveOperation(stub, MatriculationDataContract.contractName,"addMatriculationData", ids, input);
-            // utilize one id here to test implicit approval by transaction execution
-            Context ctx = TestUtil.mockContext(stub, ids.get(0));
+            Context ctx = TestUtil.buildContext(MatriculationDataContract.contractName, MatriculationDataContract.transactionNameAddMatriculationData, setup, input, ids);
 
             String result = contract.addMatriculationData(ctx, input.get(0));
             assertThat(result).isEqualTo(compare.get(0));
@@ -106,9 +101,7 @@ public final class MatriculationDataContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.MatriculationData:addMatriculationData");
-            TestUtil.approveOperation(stub, MatriculationDataContract.contractName,"addMatriculationData", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(MatriculationDataContract.contractName, MatriculationDataContract.transactionNameAddMatriculationData, setup, input, ids);
 
             String result = contract.addMatriculationData(ctx, input.get(0));
             assertThat(result).isEqualTo(compare.get(0));
@@ -122,9 +115,7 @@ public final class MatriculationDataContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.MatriculationData:updateMatriculationData");
-            TestUtil.approveOperation(stub, MatriculationDataContract.contractName,"updateMatriculationData", ids, input);
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(MatriculationDataContract.contractName, MatriculationDataContract.transactionNameUpdateMatriculationData, setup, input, ids);
 
             String result = contract.updateMatriculationData(ctx, input.get(0));
             assertThat(result).isEqualTo(compare.get(0));
@@ -140,11 +131,11 @@ public final class MatriculationDataContractTest extends TestCreationBase {
     private Executable updateMatriculationDataFailureTest(
             JsonIOTestSetup setup,
             List<String> input,
-            List<String> compare
+            List<String> compare,
+            List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.MatriculationData:updateMatriculationData");
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(MatriculationDataContract.contractName, MatriculationDataContract.transactionNameUpdateMatriculationData, setup, input, ids);
 
             String result = contract.updateMatriculationData(ctx, input.get(0));
             assertThat(result).isEqualTo(compare.get(0));
@@ -158,10 +149,8 @@ public final class MatriculationDataContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.MatriculationData:addEntriesToMatriculationData");
-            TestUtil.approveOperation(stub, MatriculationDataContract.contractName,"addEntriesToMatriculationData", ids, input);
+            Context ctx = TestUtil.buildContext(MatriculationDataContract.contractName, MatriculationDataContract.transactionNameAddEntriesToMatriculationData, setup, input, ids);
 
-            Context ctx = TestUtil.mockContext(stub);
             String result = contract.addEntriesToMatriculationData(ctx, input.get(0), input.get(1));
             assertThat(result).isEqualTo(compare.get(0));
 
@@ -175,11 +164,11 @@ public final class MatriculationDataContractTest extends TestCreationBase {
     private Executable addEntriesToMatriculationDataFailureTest(
             JsonIOTestSetup setup,
             List<String> input,
-            List<String> compare
+            List<String> compare,
+            List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.MatriculationData:addEntriesToMatriculationData");
-            Context ctx = TestUtil.mockContext(stub);
+            Context ctx = TestUtil.buildContext(MatriculationDataContract.contractName, MatriculationDataContract.transactionNameAddEntriesToMatriculationData, setup, input, ids);
 
             String result = contract.addEntriesToMatriculationData(ctx, input.get(0), input.get(1));
             assertThat(result).isEqualTo(compare.get(0));

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/OperationContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/OperationContractTest.java
@@ -63,7 +63,7 @@ public final class OperationContractTest extends TestCreationBase {
             List<String> compare
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.OperationData:getOperations");
+            MockChaincodeStub stub = TestUtil.mockStub(setup, OperationContract.contractName + ":" + OperationContract.transactionNameGetOperations);
             Context ctx = TestUtil.mockContext(stub);
 
             for (int i = 0; i < compare.size(); i++) {
@@ -85,7 +85,7 @@ public final class OperationContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.OperationData:approveTransaction");
+            MockChaincodeStub stub = TestUtil.mockStub(setup, OperationContract.contractName + ":" + OperationContract.transactionNameApproveOperation);
             for (int i = 0; i < ids.size(); i++) {
                 Context ctx = TestUtil.mockContext(stub, ids.get(i));
                 OperationData compareResult = GsonWrapper.fromJson(compare.get(i), OperationData.class);
@@ -102,7 +102,7 @@ public final class OperationContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.OperationData:approveTransaction");
+            MockChaincodeStub stub = TestUtil.mockStub(setup, OperationContract.contractName + ":" + OperationContract.transactionNameApproveOperation);
             for (String s : compare) {
                 Context ctx = cUtil.valueUnset(ids) ? TestUtil.mockContext(stub) : TestUtil.mockContext(stub, ids.get(0));
                 String result = contract.initiateOperation(ctx, "", contract(input), transaction(input), params(input));
@@ -118,7 +118,7 @@ public final class OperationContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.OperationData:rejectTransaction");
+            MockChaincodeStub stub = TestUtil.mockStub(setup, OperationContract.contractName + ":" + OperationContract.transactionNameRejectOperation);
             Context ctx = TestUtil.mockContext(stub, ids.get(0));
             String rejectResult = contract.rejectOperation(ctx, input.get(0), input.get(1));
             OperationData compareOperationData = GsonWrapper.fromJson(compare.get(compare.size() - 1), OperationData.class);
@@ -137,12 +137,7 @@ public final class OperationContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.OperationData:rejectTransaction");
-            /*for (String s : compare) {
-                Context ctx = cUtil.valueUnset(ids) ? TestUtil.mockContext(stub) : TestUtil.mockContext(stub, ids.get(0));
-                String result = contract.approveTransaction(ctx, contract(input), transaction(input), params(input));
-                assertThat(result).isEqualTo(s);
-            }*/
+            MockChaincodeStub stub = TestUtil.mockStub(setup, OperationContract.contractName + ":" + OperationContract.transactionNameRejectOperation);
             Context ctx = TestUtil.mockContext(stub, ids.get(0));
             String result = contract.rejectOperation(ctx, input.get(0), input.get(1));
             assertThat(result).isEqualTo(compare.get(0));
@@ -156,7 +151,7 @@ public final class OperationContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            MockChaincodeStub stub = TestUtil.mockStub(setup, "UC4.OperationData:approveTransaction");
+            MockChaincodeStub stub = TestUtil.mockStub(setup, OperationContract.contractName + ":" + OperationContract.transactionNameApproveOperation);
             String operationJson = "";
             for (String id: ids) {
                 Context ctx = TestUtil.mockContext(stub, id);

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/util/TestUtil.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/util/TestUtil.java
@@ -1,5 +1,6 @@
 package de.upb.cs.uc4.chaincode.util;
 
+import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContract;
 import de.upb.cs.uc4.chaincode.contract.certificate.CertificateContract;
 import de.upb.cs.uc4.chaincode.contract.operation.OperationContract;
 import de.upb.cs.uc4.chaincode.helper.GsonWrapper;
@@ -73,5 +74,11 @@ public class TestUtil {
             Context ctx = TestUtil.mockContext(stub, id);
             operationContract.initiateOperation(ctx, ids.get(0), contractName, transactionName, GsonWrapper.toJson(input));
         }
+    }
+
+    public static Context buildContext(String contractName, String transactionName, JsonIOTestSetup setup, List<String> input, List<String> ids) {
+        MockChaincodeStub stub = TestUtil.mockStub(setup, contractName + ":" + transactionName);
+        TestUtil.approveOperation(stub, contractName, transactionName, ids, input);
+        return TestUtil.mockContext(stub);
     }
 }


### PR DESCRIPTION
### Reason for this PR
- magic strings such as transaction names should not appear multiple times in code

### Changes in this PR
- store transaction names in static variables
- refactor common test setup (context setup)
