### PR TITLE
Feature/admission extension

### DIFF
--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/ContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/ContractUtil.java
@@ -27,6 +27,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 
@@ -278,7 +279,7 @@ abstract public class ContractUtil {
         deleteStringState(stub, key);
     }
 
-    public <T> ArrayList<T> getAllStates(ChaincodeStub stub, Class<T> c) {
+    public <T> List<T> getAllStates(ChaincodeStub stub, Class<T> c) {
         QueryResultsIterator<KeyValue> qrIterator;
         qrIterator = getAllRawStates(stub);
         ArrayList<T> resultItems = new ArrayList<>();

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContract.java
@@ -42,8 +42,9 @@ public class AdmissionContract extends ContractBase {
     @Transaction()
     public String addAdmission(final Context ctx, String admissionJson) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
+        final String[] args = new String[]{admissionJson};
         try {
-            cUtil.checkParamsAddAdmission(ctx, Collections.singletonList(admissionJson));
+            cUtil.checkParamsAddAdmission(ctx, args);
         } catch (ParameterError e) {
             return e.getJsonError();
         }
@@ -53,12 +54,12 @@ public class AdmissionContract extends ContractBase {
         newAdmission.resetAdmissionId();
 
         try {
-            cUtil.validateApprovals(ctx, contractName,  transactionName, new String[]{admissionJson});
+            cUtil.validateApprovals(ctx, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
         try {
-            cUtil.finishOperation(stub, contractName,  transactionName, new String[]{admissionJson});
+            cUtil.finishOperation(stub, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -76,15 +77,16 @@ public class AdmissionContract extends ContractBase {
     @Transaction()
     public String dropAdmission(final Context ctx, String admissionId) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
+        final String[] args = new String[]{admissionId};
         try {
-            cUtil.checkParamsDropAdmission(ctx, Collections.singletonList(admissionId));
+            cUtil.checkParamsDropAdmission(ctx, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(ctx, contractName,  transactionName, new String[]{admissionId});
+            cUtil.validateApprovals(ctx, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -96,7 +98,7 @@ public class AdmissionContract extends ContractBase {
             return e.getJsonError();
         }
         try {
-            cUtil.finishOperation(stub, contractName,  transactionName, new String[]{admissionId});
+            cUtil.finishOperation(stub, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -115,16 +117,16 @@ public class AdmissionContract extends ContractBase {
     @Transaction()
     public String getCourseAdmissions(final Context ctx, final String enrollmentId, final String courseId, final String moduleId) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
-
+        final String[] args = new String[]{enrollmentId, courseId, moduleId};
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(ctx, contractName,  transactionName, new String[]{enrollmentId, courseId, moduleId});
+            cUtil.validateApprovals(ctx, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
         List<CourseAdmission> admissions = cUtil.getCourseAdmissions(stub, enrollmentId, courseId, moduleId);
         try {
-            cUtil.finishOperation(stub, contractName,  transactionName, new String[]{enrollmentId, courseId, moduleId});
+            cUtil.finishOperation(stub, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -135,7 +137,9 @@ public class AdmissionContract extends ContractBase {
      * Gets ExamAdmissionList from the ledger.
      *
      * @param ctx          transaction context providing access to ChaincodeStub etc.
+     * @param admissionIds admissionIds to filter admissions by
      * @param enrollmentId enrollment to filter admissions by
+     * @param examIds examIds to filter admissions by
      * @return Serialized List of Matching Admissions on success, serialized error on failure
      */
     @Transaction()

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContract.java
@@ -106,7 +106,7 @@ public class AdmissionContract extends ContractBase {
      * @return Serialized List of Matching Admissions on success, serialized error on failure
      */
     @Transaction()
-    public String getAdmissions(final Context ctx, final String enrollmentId, final String courseId, final String moduleId) {
+    public String getCourseAdmissions(final Context ctx, final String enrollmentId, final String courseId, final String moduleId) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
 
         ChaincodeStub stub = ctx.getStub();
@@ -115,7 +115,7 @@ public class AdmissionContract extends ContractBase {
         } catch (SerializableError e) {
             return e.getJsonError();
         }
-        List<CourseAdmission> admissions = cUtil.getAdmissions(stub, enrollmentId, courseId, moduleId);
+        List<CourseAdmission> admissions = cUtil.getCourseAdmissions(stub, enrollmentId, courseId, moduleId);
         try {
             cUtil.finishOperation(stub, contractName,  transactionName, new String[]{enrollmentId, courseId, moduleId});
         } catch (SerializableError e) {

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContract.java
@@ -5,7 +5,8 @@ import de.upb.cs.uc4.chaincode.exceptions.SerializableError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.LedgerAccessError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.ParameterError;
 import de.upb.cs.uc4.chaincode.helper.HyperledgerManager;
-import de.upb.cs.uc4.chaincode.model.Admission;
+import de.upb.cs.uc4.chaincode.model.admission.AbstractAdmission;
+import de.upb.cs.uc4.chaincode.model.admission.CourseAdmission;
 import de.upb.cs.uc4.chaincode.helper.GsonWrapper;
 import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.contract.annotation.Contract;
@@ -43,7 +44,7 @@ public class AdmissionContract extends ContractBase {
         }
 
         ChaincodeStub stub = ctx.getStub();
-        Admission newAdmission = GsonWrapper.fromJson(admissionJson, Admission.class);
+        AbstractAdmission newAdmission = GsonWrapper.fromJson(admissionJson, AbstractAdmission.class);
         newAdmission.resetAdmissionId();
 
         try {
@@ -114,7 +115,7 @@ public class AdmissionContract extends ContractBase {
         } catch (SerializableError e) {
             return e.getJsonError();
         }
-        List<Admission> admissions = cUtil.getAdmissions(stub, enrollmentId, courseId, moduleId);
+        List<CourseAdmission> admissions = cUtil.getAdmissions(stub, enrollmentId, courseId, moduleId);
         try {
             cUtil.finishOperation(stub, contractName,  transactionName, new String[]{enrollmentId, courseId, moduleId});
         } catch (SerializableError e) {

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContract.java
@@ -158,7 +158,7 @@ public class AdmissionContract extends ContractBase {
         } catch (SerializableError e) {
             return e.getJsonError();
         }
-        Type listType = new TypeToken<String[]>() {}.getType();
+        Type listType = new TypeToken<ArrayList<String>>() {}.getType();
         ArrayList<String> admissionIdList = GsonWrapper.fromJson(admissionIds, listType);
         ArrayList<String> examIdList = GsonWrapper.fromJson(examIds, listType);
         List<ExamAdmission> admissions = cUtil.getExamAdmissions(stub, admissionIdList, enrollmentId, examIdList);

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContract.java
@@ -159,8 +159,8 @@ public class AdmissionContract extends ContractBase {
             return e.getJsonError();
         }
         Type listType = new TypeToken<ArrayList<String>>() {}.getType();
-        ArrayList<String> admissionIdList = GsonWrapper.fromJson(admissionIds, listType);
-        ArrayList<String> examIdList = GsonWrapper.fromJson(examIds, listType);
+        List<String> admissionIdList = GsonWrapper.fromJson(admissionIds, listType);
+        List<String> examIdList = GsonWrapper.fromJson(examIds, listType);
         List<ExamAdmission> admissions = cUtil.getExamAdmissions(stub, admissionIdList, enrollmentId, examIdList);
         try {
             cUtil.finishOperation(stub, contractName,  transactionName, args);

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContractUtil.java
@@ -3,6 +3,7 @@ package de.upb.cs.uc4.chaincode.contract.admission;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.LedgerAccessError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.ParameterError;
 import de.upb.cs.uc4.chaincode.model.*;
+import de.upb.cs.uc4.chaincode.model.admission.CourseAdmission;
 import de.upb.cs.uc4.chaincode.model.errors.InvalidParameter;
 import de.upb.cs.uc4.chaincode.contract.ContractUtil;
 import de.upb.cs.uc4.chaincode.contract.examinationregulation.ExaminationRegulationContractUtil;
@@ -35,8 +36,8 @@ public class AdmissionContractUtil extends ContractUtil {
                 .reason("The student is not matriculated in any examinationRegulation containing the module he is trying to enroll in");
     }
 
-    public List<Admission> getAdmissions(ChaincodeStub stub, String enrollmentId, String courseId, String moduleId) {
-        return this.getAllStates(stub, Admission.class).stream()
+    public List<CourseAdmission> getAdmissions(ChaincodeStub stub, String enrollmentId, String courseId, String moduleId) {
+        return this.getAllStates(stub, CourseAdmission.class).stream()
                 .filter(item -> enrollmentId.isEmpty() || item.getEnrollmentId().equals(enrollmentId))
                 .filter(item -> courseId.isEmpty() || item.getCourseId().equals(courseId))
                 .filter(item -> moduleId.isEmpty() || item.getModuleId().equals(moduleId)).collect(Collectors.toList());
@@ -50,7 +51,7 @@ public class AdmissionContractUtil extends ContractUtil {
      */
     public ArrayList<InvalidParameter> getSemanticErrorsForAdmission(
             ChaincodeStub stub,
-            Admission admission) {
+            CourseAdmission admission) {
 
         ArrayList<InvalidParameter> invalidParameters = new ArrayList<>();
 
@@ -62,7 +63,7 @@ public class AdmissionContractUtil extends ContractUtil {
         return invalidParameters;
     }
 
-    private boolean checkModuleAvailable(ChaincodeStub stub, Admission admission) {
+    private boolean checkModuleAvailable(ChaincodeStub stub, CourseAdmission admission) {
         ExaminationRegulationContractUtil erUtil = new ExaminationRegulationContractUtil();
         MatriculationDataContractUtil matUtil = new MatriculationDataContractUtil();
 
@@ -93,7 +94,7 @@ public class AdmissionContractUtil extends ContractUtil {
      * @return a list of all errors found for the given matriculationData
      */
     public ArrayList<InvalidParameter> getParameterErrorsForAdmission(
-            Admission admission) {
+            CourseAdmission admission) {
 
         ArrayList<InvalidParameter> invalidparams = new ArrayList<>();
 
@@ -121,9 +122,9 @@ public class AdmissionContractUtil extends ContractUtil {
 
         ChaincodeStub stub = ctx.getStub();
 
-        Admission newAdmission;
+        CourseAdmission newAdmission;
         try {
-            newAdmission = GsonWrapper.fromJson(admissionJson, Admission.class);
+            newAdmission = GsonWrapper.fromJson(admissionJson, CourseAdmission.class);
             newAdmission.resetAdmissionId();
         } catch (Exception e) {
             throw new ParameterError(GsonWrapper.toJson(getUnprocessableEntityError(getUnparsableParam("admission"))));
@@ -148,6 +149,6 @@ public class AdmissionContractUtil extends ContractUtil {
         String admissionId = params.get(0);
 
         ChaincodeStub stub = ctx.getStub();
-        getState(stub, admissionId, Admission.class);
+        getState(stub, admissionId, CourseAdmission.class);
     }
 }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContractUtil.java
@@ -53,7 +53,7 @@ public class AdmissionContractUtil extends ContractUtil {
     }
 
     public List<CourseAdmission> getCourseAdmissions(ChaincodeStub stub, String enrollmentId, String courseId, String moduleId) {
-        return this.getAllStates(stub, AbstractAdmission.class, CourseAdmission.class).stream()
+        return this.getAllStates(stub, CourseAdmission.class).stream()
                 .filter(item -> enrollmentId.isEmpty() || item.getEnrollmentId().equals(enrollmentId))
                 .filter(item -> courseId.isEmpty() || item.getCourseId().equals(courseId))
                 .filter(item -> moduleId.isEmpty() || item.getModuleId().equals(moduleId))
@@ -61,7 +61,7 @@ public class AdmissionContractUtil extends ContractUtil {
     }
 
     public List<ExamAdmission> getExamAdmissions(ChaincodeStub stub, List<String> admissionIds, String enrollmentId, List<String> examIds) {
-        return this.getAllStates(stub, AbstractAdmission.class, ExamAdmission.class).stream()
+        return this.getAllStates(stub, ExamAdmission.class).stream()
                 .filter(item -> enrollmentId.isEmpty() || item.getEnrollmentId().equals(enrollmentId))
                 .filter(item -> admissionIds.isEmpty() || admissionIds.contains(item.getAdmissionId()))
                 .filter(item -> examIds.isEmpty() || examIds.contains(item.getExamId()))
@@ -151,8 +151,9 @@ public class AdmissionContractUtil extends ContractUtil {
         }
     }
 
-    public <T1, T2> List<T2> getAllStates(ChaincodeStub stub, Class<T1> superClass, Class<T2> c) {
-        ArrayList<T1> states = super.getAllStates(stub, superClass);
-        return (List<T2>) states.stream().filter(item -> item.getClass() == c).collect(Collectors.toList());
+    @Override
+    public <T> List<T> getAllStates(ChaincodeStub stub, Class<T> c) {
+        List<AbstractAdmission> states = super.getAllStates(stub, AbstractAdmission.class);
+        return (List<T>) states.stream().filter(item -> item.getClass() == c).collect(Collectors.toList());
     }
 }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContractUtil.java
@@ -4,6 +4,7 @@ import de.upb.cs.uc4.chaincode.exceptions.serializable.LedgerAccessError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.ParameterError;
 import de.upb.cs.uc4.chaincode.model.*;
 import de.upb.cs.uc4.chaincode.model.admission.CourseAdmission;
+import de.upb.cs.uc4.chaincode.model.admission.ExamAdmission;
 import de.upb.cs.uc4.chaincode.model.errors.InvalidParameter;
 import de.upb.cs.uc4.chaincode.contract.ContractUtil;
 import de.upb.cs.uc4.chaincode.contract.examinationregulation.ExaminationRegulationContractUtil;
@@ -36,11 +37,17 @@ public class AdmissionContractUtil extends ContractUtil {
                 .reason("The student is not matriculated in any examinationRegulation containing the module he is trying to enroll in");
     }
 
-    public List<CourseAdmission> getAdmissions(ChaincodeStub stub, String enrollmentId, String courseId, String moduleId) {
+    public List<CourseAdmission> getCourseAdmissions(ChaincodeStub stub, String enrollmentId, String courseId, String moduleId) {
         return this.getAllStates(stub, CourseAdmission.class).stream()
                 .filter(item -> enrollmentId.isEmpty() || item.getEnrollmentId().equals(enrollmentId))
                 .filter(item -> courseId.isEmpty() || item.getCourseId().equals(courseId))
                 .filter(item -> moduleId.isEmpty() || item.getModuleId().equals(moduleId)).collect(Collectors.toList());
+    }
+
+    public List<ExamAdmission> getExamAdmissions(ChaincodeStub stub, String enrollmentId, String courseId, String moduleId) {
+        return this.getAllStates(stub, ExamAdmission.class).stream()
+                .filter(item -> enrollmentId.isEmpty() || item.getEnrollmentId().equals(enrollmentId)).collect(Collectors.toList());
+        // TODO add filters
     }
 
     /**

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContractUtil.java
@@ -38,6 +38,12 @@ public class AdmissionContractUtil extends ContractUtil {
                 .reason("Timestamp must be the following format \"(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\", e.g. \"2020-12-31T23:59:59\"");
     }
 
+    public InvalidParameter getInvalidTypeParam() {
+        return new InvalidParameter()
+                .name(errorPrefix + ".type")
+                .reason("Type must be one of (Course|Exam)");
+    }
+
     public InvalidParameter getInvalidModuleAvailable(String parameterName) {
         return new InvalidParameter()
                 .name(errorPrefix + "." + parameterName)
@@ -84,11 +90,11 @@ public class AdmissionContractUtil extends ContractUtil {
         return false;
     }
 
-    public void checkParamsAddAdmission(Context ctx, List<String> params) throws ParameterError {
-        if (params.size() != 1) {
+    public void checkParamsAddAdmission(Context ctx, String[] params) throws ParameterError {
+        if (params.length != 1) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        String admissionJson = params.get(0);
+        String admissionJson = params[0];
 
         ChaincodeStub stub = ctx.getStub();
 
@@ -112,14 +118,15 @@ public class AdmissionContractUtil extends ContractUtil {
         }
     }
 
-    public void checkParamsDropAdmission(Context ctx, List<String> params) throws LedgerAccessError, ParameterError {
-        if (params.size() != 1) {
+    public void checkParamsDropAdmission(Context ctx, String[] params) throws LedgerAccessError, ParameterError {
+        if (params.length != 1) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        String admissionId = params.get(0);
+        String admissionId = params[0];
 
         ChaincodeStub stub = ctx.getStub();
-        getState(stub, admissionId, AbstractAdmission.class);
+        AbstractAdmission admission = getState(stub, admissionId, AbstractAdmission.class);
+        admission.ensureIsDroppable(stub);
     }
 
     public void checkParamsGetExamAdmission(Context ctx, String[] params) throws LedgerAccessError, ParameterError {

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/certificate/CertificateContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/certificate/CertificateContract.java
@@ -35,21 +35,21 @@ public class CertificateContract extends ContractBase {
     @Transaction()
     public String addCertificate(final Context ctx, final String enrollmentId, final String certificate) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
-
+        final  String[] args = new String[]{enrollmentId, certificate};
         try {
-            cUtil.checkParamsAddCertificate(ctx, new ArrayList<String>(){{add(enrollmentId); add(certificate);}});
+            cUtil.checkParamsAddCertificate(ctx, args);
         } catch (ParameterError e) {
             return e.getJsonError();
         }
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(ctx, contractName,  transactionName, new String[]{enrollmentId, certificate});
+            cUtil.validateApprovals(ctx, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
         try {
-            cUtil.finishOperation(stub, contractName,  transactionName, new String[]{enrollmentId, certificate});
+            cUtil.finishOperation(stub, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -67,20 +67,21 @@ public class CertificateContract extends ContractBase {
     @Transaction()
     public String updateCertificate(final Context ctx, final String enrollmentId, final String certificate) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
+        final String[] args = new String[]{enrollmentId, certificate};
         try {
-            cUtil.checkParamsUpdateCertificate(ctx, new ArrayList<String>(){{add(enrollmentId); add(certificate);}});
+            cUtil.checkParamsUpdateCertificate(ctx, args);
         } catch (ParameterError e) {
             return e.getJsonError();
         }
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(ctx, contractName,  transactionName, new String[]{enrollmentId, certificate});
+            cUtil.validateApprovals(ctx, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
         try {
-            cUtil.finishOperation(stub, contractName,  transactionName, new String[]{enrollmentId, certificate});
+            cUtil.finishOperation(stub, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -97,20 +98,21 @@ public class CertificateContract extends ContractBase {
     @Transaction()
     public String getCertificate(final Context ctx, final String enrollmentId) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
+        final String[] args = new String[]{enrollmentId};
         try {
-            cUtil.checkParamsGetCertificate(ctx, Collections.singletonList(enrollmentId));
+            cUtil.checkParamsGetCertificate(ctx, args);
         } catch (ParameterError e) {
             return e.getJsonError();
         }
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(ctx, contractName,  transactionName, new String[]{enrollmentId});
+            cUtil.validateApprovals(ctx, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
         try {
-            cUtil.finishOperation(stub, contractName,  transactionName, new String[]{enrollmentId});
+            cUtil.finishOperation(stub, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/certificate/CertificateContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/certificate/CertificateContractUtil.java
@@ -34,12 +34,12 @@ public class CertificateContractUtil extends ContractUtil {
         return list;
     }
 
-    public void checkParamsAddCertificate(Context ctx, List<String> params) throws ParameterError {
-        if (params.size() != 2) {
+    public void checkParamsAddCertificate(Context ctx, String[] params) throws ParameterError {
+        if (params.length != 2) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        String enrollmentId = params.get(0);
-        String certificate = params.get(1);
+        String enrollmentId = params[0];
+        String certificate = params[1];
 
         ChaincodeStub stub = ctx.getStub();
 
@@ -57,12 +57,12 @@ public class CertificateContractUtil extends ContractUtil {
         }
     }
 
-    public void checkParamsUpdateCertificate(Context ctx, List<String> params) throws ParameterError {
-        if (params.size() != 2) {
+    public void checkParamsUpdateCertificate(Context ctx, String[] params) throws ParameterError {
+        if (params.length != 2) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        String enrollmentId = params.get(0);
-        String certificate = params.get(1);
+        String enrollmentId = params[0];
+        String certificate = params[1];
 
         ChaincodeStub stub = ctx.getStub();
 
@@ -81,11 +81,11 @@ public class CertificateContractUtil extends ContractUtil {
         }
     }
 
-    public void checkParamsGetCertificate(Context ctx, List<String> params) throws ParameterError {
-        if (params.size() != 1) {
+    public void checkParamsGetCertificate(Context ctx, String[] params) throws ParameterError {
+        if (params.length != 1) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        String enrollmentId = params.get(0);
+        String enrollmentId = params[0];
 
         ChaincodeStub stub = ctx.getStub();
 

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examinationregulation/ExaminationRegulationContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examinationregulation/ExaminationRegulationContract.java
@@ -39,21 +39,22 @@ public class ExaminationRegulationContract extends ContractBase {
     @Transaction()
     public String addExaminationRegulation(final Context ctx, final String examinationRegulation) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
+        final String[] args = new String[]{examinationRegulation};
         try {
-            cUtil.checkParamsAddExaminationRegulation(ctx, Collections.singletonList(examinationRegulation));
+            cUtil.checkParamsAddExaminationRegulation(ctx, args);
         } catch (ParameterError e) {
             return e.getJsonError();
         }
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(ctx, contractName,  transactionName, new String[]{examinationRegulation});
+            cUtil.validateApprovals(ctx, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
         ExaminationRegulation newExaminationRegulation = GsonWrapper.fromJson(examinationRegulation, ExaminationRegulation.class);
         try {
-            cUtil.finishOperation(stub, contractName,  transactionName, new String[]{examinationRegulation});
+            cUtil.finishOperation(stub, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -70,15 +71,16 @@ public class ExaminationRegulationContract extends ContractBase {
     @Transaction()
     public String getExaminationRegulations(final Context ctx, final String names) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
+        final String[] args = new String[]{names};
         try {
-            cUtil.checkParamsGetExaminationRegulations(Collections.singletonList(names));
+            cUtil.checkParamsGetExaminationRegulations(args);
         } catch (ParameterError e) {
             return e.getJsonError();
         }
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(ctx, contractName,  transactionName, new String[]{names});
+            cUtil.validateApprovals(ctx, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -111,7 +113,7 @@ public class ExaminationRegulationContract extends ContractBase {
             }
         }
         try {
-            cUtil.finishOperation(stub, contractName,  transactionName, new String[]{names});
+            cUtil.finishOperation(stub, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -128,15 +130,16 @@ public class ExaminationRegulationContract extends ContractBase {
     @Transaction()
     public String closeExaminationRegulation(final Context ctx, final String name) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
+        final String[] args = new String[]{name};
         try {
-            cUtil.checkParamsCloseExaminationRegulation(ctx, Collections.singletonList(name));
+            cUtil.checkParamsCloseExaminationRegulation(ctx, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(ctx, contractName,  transactionName, new String[]{name});
+            cUtil.validateApprovals(ctx, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -149,7 +152,7 @@ public class ExaminationRegulationContract extends ContractBase {
 
         regulation.setActive(false);
         try {
-            cUtil.finishOperation(stub, contractName,  transactionName, new String[]{name});
+            cUtil.finishOperation(stub, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examinationregulation/ExaminationRegulationContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examinationregulation/ExaminationRegulationContract.java
@@ -17,6 +17,7 @@ import org.hyperledger.fabric.shim.ChaincodeStub;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 @Contract(
         name = ExaminationRegulationContract.contractName
@@ -92,7 +93,7 @@ public class ExaminationRegulationContract extends ContractBase {
             return GsonWrapper.toJson(cUtil.getUnprocessableEntityError(cUtil.getUnparsableNameListParam()));
         }
 
-        ArrayList<ExaminationRegulation> regulations = new ArrayList<>();
+        List<ExaminationRegulation> regulations = new ArrayList<>();
         if (nameList.isEmpty()) {
             // read all existing information
             regulations = cUtil.getAllStates(stub, ExaminationRegulation.class);

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examinationregulation/ExaminationRegulationContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examinationregulation/ExaminationRegulationContractUtil.java
@@ -107,11 +107,11 @@ public class ExaminationRegulationContractUtil extends ContractUtil {
         return invalidParams;
     }
 
-    public void checkParamsAddExaminationRegulation(Context ctx, List<String> params) throws ParameterError {
-        if (params.size() != 1) {
+    public void checkParamsAddExaminationRegulation(Context ctx, String[] params) throws ParameterError {
+        if (params.length != 1) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        String examinationRegulation = params.get(0);
+        String examinationRegulation = params[0];
 
         ChaincodeStub stub = ctx.getStub();
 
@@ -135,11 +135,11 @@ public class ExaminationRegulationContractUtil extends ContractUtil {
         }
     }
 
-    public void checkParamsGetExaminationRegulations(List<String> params) throws ParameterError {
-        if (params.size() != 1) {
+    public void checkParamsGetExaminationRegulations(String[] params) throws ParameterError {
+        if (params.length != 1) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        String names = params.get(0);
+        String names = params[0];
 
         Type listType = new TypeToken<ArrayList<String>>() {}.getType();
         try {
@@ -149,11 +149,11 @@ public class ExaminationRegulationContractUtil extends ContractUtil {
         }
     }
 
-    public void checkParamsCloseExaminationRegulation(Context ctx, List<String> params) throws LedgerAccessError, ParameterError {
-        if (params.size() != 1) {
+    public void checkParamsCloseExaminationRegulation(Context ctx, String[] params) throws LedgerAccessError, ParameterError {
+        if (params.length != 1) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        String name = params.get(0);
+        String name = params[0];
 
         ChaincodeStub stub = ctx.getStub();
         getState(stub, name, ExaminationRegulation.class);

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/group/GroupContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/group/GroupContract.java
@@ -42,8 +42,9 @@ public class GroupContract extends ContractBase {
     @Transaction()
     public String addUserToGroup(final Context ctx, String enrollmentId, String groupId) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
+        final String[] args = new String[]{enrollmentId, groupId};
         try {
-            cUtil.checkParamsAddUserToGroup(ctx, new ArrayList<String>(){{add(enrollmentId); add(groupId);}});
+            cUtil.checkParamsAddUserToGroup(ctx, args);
         } catch (ParameterError e) {
             return e.getJsonError();
         }
@@ -64,14 +65,14 @@ public class GroupContract extends ContractBase {
         try {
             
             cUtil.validateAttributes(ctx, new ArrayList<String>() {{add(AccessManager.HLF_ATTRIBUTE_SYSADMIN);}});
-            cUtil.validateApprovals(ctx, contractName, transactionName, new String[]{enrollmentId, groupId});
+            cUtil.validateApprovals(ctx, contractName, transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
 
         cUtil.putAndGetStringState(stub, groupId, GsonWrapper.toJson(group));
         try {
-            cUtil.finishOperation(stub, contractName, transactionName, new String[]{enrollmentId, groupId});
+            cUtil.finishOperation(stub, contractName, transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -89,8 +90,9 @@ public class GroupContract extends ContractBase {
     @Transaction()
     public String removeUserFromGroup(final Context ctx, String enrollmentId, String groupId) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
+        final String[] args = new String[]{enrollmentId, groupId};
         try {
-            cUtil.checkParamsRemoveUserFromGroup(ctx, new ArrayList<String>(){{add(enrollmentId); add(groupId);}});
+            cUtil.checkParamsRemoveUserFromGroup(ctx, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -107,14 +109,14 @@ public class GroupContract extends ContractBase {
         try {
             
             cUtil.validateAttributes(ctx, new ArrayList<String>() {{add(AccessManager.HLF_ATTRIBUTE_SYSADMIN);}});
-            cUtil.validateApprovals(ctx, contractName, transactionName, new String[]{enrollmentId, groupId});
+            cUtil.validateApprovals(ctx, contractName, transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
 
         cUtil.putAndGetStringState(stub, groupId, GsonWrapper.toJson(group));
         try {
-            cUtil.finishOperation(stub, contractName, transactionName, new String[]{enrollmentId, groupId});
+            cUtil.finishOperation(stub, contractName, transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -131,8 +133,9 @@ public class GroupContract extends ContractBase {
     @Transaction()
     public String removeUserFromAllGroups(final Context ctx, String enrollmentId) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
+        final String[] args = new String[]{enrollmentId};
         try {
-            cUtil.checkParamsRemoveUserFromAllGroups(Collections.singletonList(enrollmentId));
+            cUtil.checkParamsRemoveUserFromAllGroups(args);
         } catch (ParameterError e) {
             return e.getJsonError();
         }
@@ -141,7 +144,7 @@ public class GroupContract extends ContractBase {
         try {
             
             cUtil.validateAttributes(ctx, new ArrayList<String>() {{add(AccessManager.HLF_ATTRIBUTE_SYSADMIN);}});
-            cUtil.validateApprovals(ctx, contractName, transactionName, new String[]{enrollmentId});
+            cUtil.validateApprovals(ctx, contractName, transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -151,7 +154,7 @@ public class GroupContract extends ContractBase {
             cUtil.putAndGetStringState(stub, group.getGroupId(), GsonWrapper.toJson(group));
         });
         try {
-            cUtil.finishOperation(stub, contractName, transactionName, new String[]{enrollmentId});
+            cUtil.finishOperation(stub, contractName, transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -191,15 +194,16 @@ public class GroupContract extends ContractBase {
     @Transaction()
     public String getUsersForGroup(final Context ctx, String groupId) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
+        final String[] args = new String[]{groupId};
         try {
-            cUtil.checkParamsGetUsersForGroup(ctx, Collections.singletonList(groupId));
+            cUtil.checkParamsGetUsersForGroup(ctx, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(ctx, contractName, transactionName, new String[]{groupId});
+            cUtil.validateApprovals(ctx, contractName, transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -210,7 +214,7 @@ public class GroupContract extends ContractBase {
             return e.getJsonError();
         }
         try {
-            cUtil.finishOperation(stub, contractName, transactionName, new String[]{groupId});
+            cUtil.finishOperation(stub, contractName, transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -227,21 +231,22 @@ public class GroupContract extends ContractBase {
     @Transaction()
     public String getGroupsForUser(final Context ctx, String enrollmentId) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
+        final String[] args = new String[]{enrollmentId};
         try {
-            cUtil.checkParamsGetGroupsForUser(Collections.singletonList(enrollmentId));
+            cUtil.checkParamsGetGroupsForUser(args);
         } catch (ParameterError e) {
             return e.getJsonError();
         }
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(ctx, contractName, transactionName, new String[]{enrollmentId});
+            cUtil.validateApprovals(ctx, contractName, transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
         List<String> groupIdList = cUtil.getGroupNamesForUser(stub, enrollmentId);
         try {
-            cUtil.finishOperation(stub, contractName, transactionName, new String[]{enrollmentId});
+            cUtil.finishOperation(stub, contractName, transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/group/GroupContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/group/GroupContractUtil.java
@@ -101,12 +101,12 @@ public class GroupContractUtil extends ContractUtil {
         return this.getGroupsForUser(stub, enrollmentId).stream().map(Group::getGroupId).collect(Collectors.toList());
     }
 
-    public void checkParamsAddUserToGroup(Context ctx, List<String> params) throws ParameterError {
-        if (params.size() != 2) {
+    public void checkParamsAddUserToGroup(Context ctx, String[] params) throws ParameterError {
+        if (params.length != 2) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        String enrollmentId = params.get(0);
-        String groupId = params.get(1);
+        String enrollmentId = params[0];
+        String groupId = params[1];
 
         ChaincodeStub stub = ctx.getStub();
 
@@ -118,12 +118,12 @@ public class GroupContractUtil extends ContractUtil {
         }
     }
 
-    public void checkParamsRemoveUserFromGroup(Context ctx, List<String> params) throws SerializableError {
-        if (params.size() != 2) {
+    public void checkParamsRemoveUserFromGroup(Context ctx, String[] params) throws SerializableError {
+        if (params.length != 2) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        String enrollmentId = params.get(0);
-        String groupId = params.get(1);
+        String enrollmentId = params[0];
+        String groupId = params[1];
 
         ChaincodeStub stub = ctx.getStub();
         ArrayList<InvalidParameter> invalidParams = getParameterErrorsForEnrollmentId(enrollmentId);
@@ -137,11 +137,11 @@ public class GroupContractUtil extends ContractUtil {
         }
     }
 
-    public void checkParamsRemoveUserFromAllGroups(List<String> params) throws ParameterError {
-        if (params.size() != 1) {
+    public void checkParamsRemoveUserFromAllGroups(String[] params) throws ParameterError {
+        if (params.length != 1) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        String enrollmentId = params.get(0);
+        String enrollmentId = params[0];
 
         ArrayList<InvalidParameter> invalidParams = getParameterErrorsForEnrollmentId(enrollmentId);
         if (!invalidParams.isEmpty()) {
@@ -149,11 +149,11 @@ public class GroupContractUtil extends ContractUtil {
         }
     }
 
-    public void checkParamsGetUsersForGroup(Context ctx, List<String> params) throws SerializableError {
-        if (params.size() != 1) {
+    public void checkParamsGetUsersForGroup(Context ctx, String[] params) throws SerializableError {
+        if (params.length != 1) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        String groupId = params.get(0);
+        String groupId = params[0];
 
         ChaincodeStub stub = ctx.getStub();
         ArrayList<InvalidParameter> invalidParams = getParameterErrorsForGroupId(groupId);
@@ -164,11 +164,11 @@ public class GroupContractUtil extends ContractUtil {
 
     }
 
-    public void checkParamsGetGroupsForUser(List<String> params) throws ParameterError {
-        if (params.size() != 1) {
+    public void checkParamsGetGroupsForUser(String[] params) throws ParameterError {
+        if (params.length != 1) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        String enrollmentId = params.get(0);
+        String enrollmentId = params[0];
 
         ArrayList<InvalidParameter> invalidParams = getParameterErrorsForEnrollmentId(enrollmentId);
         if (!invalidParams.isEmpty()) {

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/matriculationdata/MatriculationDataContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/matriculationdata/MatriculationDataContract.java
@@ -40,22 +40,23 @@ public class MatriculationDataContract extends ContractBase {
     @Transaction()
     public String addMatriculationData(final Context ctx, String matriculationData) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
+        final String[] args = new String[]{matriculationData};
         try {
-            cUtil.checkParamsAddMatriculationData(ctx, Collections.singletonList(matriculationData));
+            cUtil.checkParamsAddMatriculationData(ctx, args);
         } catch (ParameterError e) {
             return e.getJsonError();
         }
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(ctx, contractName,  transactionName, new String[]{matriculationData});
+            cUtil.validateApprovals(ctx, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
 
         MatriculationData newMatriculationData = GsonWrapper.fromJson(matriculationData, MatriculationData.class);
         try {
-            cUtil.finishOperation(stub, contractName,  transactionName, new String[]{matriculationData});
+            cUtil.finishOperation(stub, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -72,21 +73,22 @@ public class MatriculationDataContract extends ContractBase {
     @Transaction()
     public String updateMatriculationData(final Context ctx, String matriculationData) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
+        final String[] args = new String[]{matriculationData};
         try {
-            cUtil.checkParamsUpdateMatriculationData(ctx, Collections.singletonList(matriculationData));
+            cUtil.checkParamsUpdateMatriculationData(ctx, args);
         } catch (ParameterError e) {
             return e.getJsonError();
         }
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(ctx, contractName,  transactionName, new String[]{matriculationData});
+            cUtil.validateApprovals(ctx, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
         MatriculationData newMatriculationData = GsonWrapper.fromJson(matriculationData, MatriculationData.class);
         try {
-            cUtil.finishOperation(stub, contractName,  transactionName, new String[]{matriculationData});
+            cUtil.finishOperation(stub, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -103,15 +105,16 @@ public class MatriculationDataContract extends ContractBase {
     @Transaction()
     public String getMatriculationData(final Context ctx, final String enrollmentId) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
+        final String[] args = new String[]{enrollmentId};
         try {
-            cUtil.checkParamsGetMatriculationData(ctx, Collections.singletonList(enrollmentId));
+            cUtil.checkParamsGetMatriculationData(ctx, args);
         } catch (ParameterError e) {
             return e.getJsonError();
         }
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(ctx, contractName,  transactionName, new String[]{enrollmentId});
+            cUtil.validateApprovals(ctx, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -122,7 +125,7 @@ public class MatriculationDataContract extends ContractBase {
             return e.getJsonError();
         }
         try {
-            cUtil.finishOperation(stub, contractName,  transactionName, new String[]{enrollmentId});
+            cUtil.finishOperation(stub, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -143,15 +146,16 @@ public class MatriculationDataContract extends ContractBase {
             final String enrollmentId,
             final String matriculations) {
         String transactionName = HyperledgerManager.getTransactionName(ctx.getStub());
+        final String[] args = new String[]{enrollmentId, matriculations};
         try {
-            cUtil.checkParamsAddEntriesToMatriculationData(ctx, new ArrayList<String>(){{add(enrollmentId); add(matriculations);}});
+            cUtil.checkParamsAddEntriesToMatriculationData(ctx, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
 
         ChaincodeStub stub = ctx.getStub();
         try {
-            cUtil.validateApprovals(ctx, contractName,  transactionName, new String[]{enrollmentId, matriculations});
+            cUtil.validateApprovals(ctx, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }
@@ -168,7 +172,7 @@ public class MatriculationDataContract extends ContractBase {
 
         matriculationData.addAbsent(matriculationStatus);
         try {
-            cUtil.finishOperation(stub, contractName,  transactionName, new String[]{enrollmentId, matriculations});
+            cUtil.finishOperation(stub, contractName,  transactionName, args);
         } catch (SerializableError e) {
             return e.getJsonError();
         }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/matriculationdata/MatriculationDataContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/matriculationdata/MatriculationDataContractUtil.java
@@ -164,11 +164,11 @@ public class MatriculationDataContractUtil extends ContractUtil {
         return true;
     }
 
-    public void checkParamsAddMatriculationData(Context ctx, List<String> params) throws ParameterError {
-        if (params.size() != 1) {
+    public void checkParamsAddMatriculationData(Context ctx, String[] params) throws ParameterError {
+        if (params.length != 1) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        String matriculationData = params.get(0);
+        String matriculationData = params[0];
 
         ChaincodeStub stub = ctx.getStub();
 
@@ -189,11 +189,11 @@ public class MatriculationDataContractUtil extends ContractUtil {
         }
     }
 
-    public void checkParamsUpdateMatriculationData(Context ctx, List<String> params) throws ParameterError {
-        if (params.size() != 1) {
+    public void checkParamsUpdateMatriculationData(Context ctx, String[] params) throws ParameterError {
+        if (params.length != 1) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        String matriculationData = params.get(0);
+        String matriculationData = params[0];
 
         ChaincodeStub stub = ctx.getStub();
 
@@ -214,11 +214,11 @@ public class MatriculationDataContractUtil extends ContractUtil {
         }
     }
 
-    public void checkParamsGetMatriculationData(Context ctx, List<String> params) throws ParameterError {
-        if (params.size() != 1) {
+    public void checkParamsGetMatriculationData(Context ctx, String[] params) throws ParameterError {
+        if (params.length != 1) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        String enrollmentId = params.get(0);
+        String enrollmentId = params[0];
 
         ChaincodeStub stub = ctx.getStub();
         try {
@@ -228,12 +228,12 @@ public class MatriculationDataContractUtil extends ContractUtil {
         }
     }
 
-    public void checkParamsAddEntriesToMatriculationData(Context ctx, List<String> params) throws SerializableError {
-        if (params.size() != 2) {
+    public void checkParamsAddEntriesToMatriculationData(Context ctx, String[] params) throws SerializableError {
+        if (params.length != 2) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        String enrollmentId = params.get(0);
-        String matriculations = params.get(1);
+        String enrollmentId = params[0];
+        String matriculations = params[1];
 
         ChaincodeStub stub = ctx.getStub();
 

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/operation/OperationContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/operation/OperationContract.java
@@ -126,7 +126,7 @@ public class OperationContract extends ContractBase {
             try {
                 operationIdList = GsonWrapper.fromJson(operationIds, listType);
             } catch (Exception e) {
-                return  new ParameterError(GsonWrapper.toJson(cUtil.getUnprocessableEntityError(cUtil.getUnparsableParam("operationIds")))).getJsonError();
+                return  GsonWrapper.toJson(cUtil.getUnprocessableEntityError(cUtil.getUnparsableParam("operationIds")));
             }
         }
         List<String> stateList = new ArrayList<>();
@@ -134,7 +134,7 @@ public class OperationContract extends ContractBase {
             try {
                 stateList = GsonWrapper.fromJson(states, listType);
             } catch (Exception e) {
-                return  new ParameterError(GsonWrapper.toJson(cUtil.getUnprocessableEntityError(cUtil.getUnparsableParam("states")))).getJsonError();
+                return GsonWrapper.toJson(cUtil.getUnprocessableEntityError(cUtil.getUnparsableParam("states")));
             }
         }
 

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/AccessManager.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/AccessManager.java
@@ -10,7 +10,7 @@ import de.upb.cs.uc4.chaincode.contract.matriculationdata.MatriculationDataContr
 import de.upb.cs.uc4.chaincode.contract.operation.OperationContractUtil;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.LedgerAccessError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.parameter.MissingTransactionError;
-import de.upb.cs.uc4.chaincode.model.Admission;
+import de.upb.cs.uc4.chaincode.model.admission.CourseAdmission;
 import de.upb.cs.uc4.chaincode.model.ApprovalList;
 import de.upb.cs.uc4.chaincode.model.MatriculationData;
 import org.hyperledger.fabric.contract.Context;
@@ -149,7 +149,7 @@ public class AccessManager {
     }
 
     private static ApprovalList getRequiredApprovalsForAddAdmission(Context ctx, List<String> params) {
-        Admission admission = GsonWrapper.fromJson(params.get(0), Admission.class);
+        CourseAdmission admission = GsonWrapper.fromJson(params.get(0), CourseAdmission.class);
         return new ApprovalList()
                 .addUsersItem(admission.getEnrollmentId())
                 .addGroupsItem(SYSTEM);
@@ -157,7 +157,7 @@ public class AccessManager {
 
     private static ApprovalList getRequiredApprovalsForDropAdmission(Context ctx, List<String> params) throws LedgerAccessError {
         AdmissionContractUtil cUtil = new AdmissionContractUtil();
-        Admission admission = cUtil.getState(ctx.getStub(), params.get(0), Admission.class);
+        CourseAdmission admission = cUtil.getState(ctx.getStub(), params.get(0), CourseAdmission.class);
         return new ApprovalList()
                 .addUsersItem(admission.getEnrollmentId())
                 .addGroupsItem(SYSTEM);

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/AccessManager.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/AccessManager.java
@@ -10,7 +10,7 @@ import de.upb.cs.uc4.chaincode.contract.matriculationdata.MatriculationDataContr
 import de.upb.cs.uc4.chaincode.contract.operation.OperationContractUtil;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.LedgerAccessError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.parameter.MissingTransactionError;
-import de.upb.cs.uc4.chaincode.model.admission.CourseAdmission;
+import de.upb.cs.uc4.chaincode.model.admission.AbstractAdmission;
 import de.upb.cs.uc4.chaincode.model.ApprovalList;
 import de.upb.cs.uc4.chaincode.model.MatriculationData;
 import org.hyperledger.fabric.contract.Context;
@@ -55,8 +55,10 @@ public class AccessManager {
                         return getRequiredApprovalsForAddAdmission(ctx, paramList);
                     case AdmissionContract.transactionNameDropAdmission:
                         return getRequiredApprovalsForDropAdmission(ctx, paramList);
-                    case AdmissionContract.transactionNameGetAdmissions:
-                        return getRequiredApprovalsForGetAdmissions(ctx, paramList);
+                    case AdmissionContract.transactionNameGetCourseAdmissions:
+                        return getRequiredApprovalsForGetCourseAdmissions(ctx, paramList);
+                    case AdmissionContract.transactionNameGetExamAdmissions:
+                        return getRequiredApprovalsForGetExamAdmissions(ctx, paramList);
                     case AdmissionContract.transactionNameGetVersion:
                         return new ApprovalList();
                     case "":
@@ -149,7 +151,7 @@ public class AccessManager {
     }
 
     private static ApprovalList getRequiredApprovalsForAddAdmission(Context ctx, List<String> params) {
-        CourseAdmission admission = GsonWrapper.fromJson(params.get(0), CourseAdmission.class);
+        AbstractAdmission admission = GsonWrapper.fromJson(params.get(0), AbstractAdmission.class);
         return new ApprovalList()
                 .addUsersItem(admission.getEnrollmentId())
                 .addGroupsItem(SYSTEM);
@@ -157,13 +159,18 @@ public class AccessManager {
 
     private static ApprovalList getRequiredApprovalsForDropAdmission(Context ctx, List<String> params) throws LedgerAccessError {
         AdmissionContractUtil cUtil = new AdmissionContractUtil();
-        CourseAdmission admission = cUtil.getState(ctx.getStub(), params.get(0), CourseAdmission.class);
+        AbstractAdmission admission = cUtil.getState(ctx.getStub(), params.get(0), AbstractAdmission.class);
         return new ApprovalList()
                 .addUsersItem(admission.getEnrollmentId())
                 .addGroupsItem(SYSTEM);
     }
 
-    private static ApprovalList getRequiredApprovalsForGetAdmissions(Context ctx, List<String> params) {
+    private static ApprovalList getRequiredApprovalsForGetCourseAdmissions(Context ctx, List<String> params) {
+        return new ApprovalList()
+                .addGroupsItem(SYSTEM);
+    }
+
+    private static ApprovalList getRequiredApprovalsForGetExamAdmissions(Context ctx, List<String> params) {
         return new ApprovalList()
                 .addGroupsItem(SYSTEM);
     }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/GsonWrapper.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/GsonWrapper.java
@@ -64,6 +64,7 @@ public class GsonWrapper {
             .registerTypeAdapter(
                     AbstractAdmission.class,
                     (JsonDeserializer<AbstractAdmission>) (json, type, jsonDeserializationContext) -> {
+                        // TODO throw proper error if type field unset/does not exist
                         JsonObject wrapper = (JsonObject) json;
                         AdmissionType admissionType = jsonDeserializationContext.deserialize(wrapper.get("type"), AdmissionType.class);
                         return jsonDeserializationContext.deserialize(json, admissionType.getAdmissionType());

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/GsonWrapper.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/GsonWrapper.java
@@ -2,6 +2,8 @@ package de.upb.cs.uc4.chaincode.helper;
 
 import com.google.gson.*;
 import de.upb.cs.uc4.chaincode.model.Dummy;
+import de.upb.cs.uc4.chaincode.model.admission.AbstractAdmission;
+import de.upb.cs.uc4.chaincode.model.admission.AdmissionType;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
 
@@ -59,6 +61,13 @@ public class GsonWrapper {
                     String.class,
                     (JsonDeserializer<String>) (json, type, jsonDeserializationContext) ->
                             Jsoup.clean(json.getAsJsonPrimitive().getAsString(), Whitelist.none()))
+            .registerTypeAdapter(
+                    AbstractAdmission.class,
+                    (JsonDeserializer<AbstractAdmission>) (json, type, jsonDeserializationContext) -> {
+                        JsonObject wrapper = (JsonObject) json;
+                        AdmissionType admissionType = jsonDeserializationContext.deserialize(wrapper.get("type"), AdmissionType.class);
+                        return jsonDeserializationContext.deserialize(json, admissionType.getAdmissionType());
+                    })
             .create();
 
     public static <T> T fromJson(String json, Class<T> t) throws JsonSyntaxException {

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/GsonWrapper.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/GsonWrapper.java
@@ -1,7 +1,6 @@
 package de.upb.cs.uc4.chaincode.helper;
 
 import com.google.gson.*;
-import de.upb.cs.uc4.chaincode.exceptions.serializable.ParameterError;
 import de.upb.cs.uc4.chaincode.model.Dummy;
 import de.upb.cs.uc4.chaincode.model.admission.AbstractAdmission;
 import de.upb.cs.uc4.chaincode.model.admission.AdmissionType;
@@ -67,11 +66,8 @@ public class GsonWrapper {
                     (JsonDeserializer<AbstractAdmission>) (json, type, jsonDeserializationContext) -> {
                         JsonObject wrapper = (JsonObject) json;
                         JsonElement jsonType = wrapper.get("type");
-                        if (jsonType == null) {
-                            // TODO throw proper error if type field unset/does not exist
-                        }
                         AdmissionType admissionType = jsonDeserializationContext.deserialize(jsonType, AdmissionType.class);
-                        return jsonDeserializationContext.deserialize(json, admissionType.getAdmissionType());
+                        return jsonDeserializationContext.deserialize(json, admissionType.valueToType());
                     })
             .create();
 

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/GsonWrapper.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/GsonWrapper.java
@@ -1,6 +1,7 @@
 package de.upb.cs.uc4.chaincode.helper;
 
 import com.google.gson.*;
+import de.upb.cs.uc4.chaincode.exceptions.serializable.ParameterError;
 import de.upb.cs.uc4.chaincode.model.Dummy;
 import de.upb.cs.uc4.chaincode.model.admission.AbstractAdmission;
 import de.upb.cs.uc4.chaincode.model.admission.AdmissionType;
@@ -64,9 +65,12 @@ public class GsonWrapper {
             .registerTypeAdapter(
                     AbstractAdmission.class,
                     (JsonDeserializer<AbstractAdmission>) (json, type, jsonDeserializationContext) -> {
-                        // TODO throw proper error if type field unset/does not exist
                         JsonObject wrapper = (JsonObject) json;
-                        AdmissionType admissionType = jsonDeserializationContext.deserialize(wrapper.get("type"), AdmissionType.class);
+                        JsonElement jsonType = wrapper.get("type");
+                        if (jsonType == null) {
+                            // TODO throw proper error if type field unset/does not exist
+                        }
+                        AdmissionType admissionType = jsonDeserializationContext.deserialize(jsonType, AdmissionType.class);
                         return jsonDeserializationContext.deserialize(json, admissionType.getAdmissionType());
                     })
             .create();

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/ValidationManager.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/ValidationManager.java
@@ -12,7 +12,6 @@ import de.upb.cs.uc4.chaincode.contract.group.GroupContractUtil;
 import de.upb.cs.uc4.chaincode.contract.matriculationdata.MatriculationDataContract;
 import de.upb.cs.uc4.chaincode.contract.matriculationdata.MatriculationDataContractUtil;
 import de.upb.cs.uc4.chaincode.contract.operation.OperationContractUtil;
-import de.upb.cs.uc4.chaincode.exceptions.serializable.ParameterError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.parameter.MissingTransactionError;
 import de.upb.cs.uc4.chaincode.exceptions.SerializableError;
 import org.hyperledger.fabric.contract.Context;
@@ -63,7 +62,7 @@ public class ValidationManager {
                     case AdmissionContract.transactionNameDropAdmission:
                         admissionUtil.checkParamsDropAdmission(ctx, paramList);
                         break;
-                    case AdmissionContract.transactionNameGetAdmissions:
+                    case AdmissionContract.transactionNameGetCourseAdmissions:
                         // pass
                         break;
                     case AdmissionContract.transactionNameGetVersion:

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/ValidationManager.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/ValidationManager.java
@@ -29,8 +29,8 @@ public class ValidationManager {
     private static MatriculationDataContractUtil matriculationDataUtil = new MatriculationDataContractUtil();
 
     public static void validateParams(Context ctx, String contractName, String transactionName, String params) throws SerializableError {
-        Type listType = new TypeToken<ArrayList<String>>() {}.getType();
-        List<String> paramList = GsonWrapper.fromJson(params, listType);
+        Type listType = new TypeToken<String[]>() {}.getType();
+        String[] paramList = GsonWrapper.fromJson(params, listType);
         switch (contractName) {
             case MatriculationDataContract.contractName:
                 switch (transactionName) {

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/ValidationManager.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/ValidationManager.java
@@ -65,6 +65,9 @@ public class ValidationManager {
                     case AdmissionContract.transactionNameGetCourseAdmissions:
                         // pass
                         break;
+                    case AdmissionContract.transactionNameGetExamAdmissions:
+                        admissionUtil.checkParamsGetExamAdmission(ctx, paramList);
+                        break;
                     case AdmissionContract.transactionNameGetVersion:
                         break;
                     case "":

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/AbstractAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/AbstractAdmission.java
@@ -1,6 +1,7 @@
 package de.upb.cs.uc4.chaincode.model.admission;
 
 import com.google.gson.annotations.SerializedName;
+import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContractUtil;
 import de.upb.cs.uc4.chaincode.model.errors.InvalidParameter;
 import io.swagger.annotations.ApiModelProperty;
 import org.hyperledger.fabric.shim.ChaincodeStub;
@@ -104,7 +105,25 @@ public abstract class AbstractAdmission {
         return o.toString().replace("\n", "\n    ");
     }
 
-    public abstract ArrayList<InvalidParameter> getParameterErrors();
+    public ArrayList<InvalidParameter> getParameterErrors() {
+        AdmissionContractUtil cUtil = new AdmissionContractUtil();
+        ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
+
+        if (cUtil.valueUnset(this.enrollmentId)) {
+            invalidParams.add(cUtil.getEmptyEnrollmentIdParam(cUtil.getErrorPrefix() + "."));
+        }
+        if (cUtil.valueUnset(this.timestamp)) {
+            invalidParams.add(cUtil.getInvalidTimestampParam());
+        }
+        if (cUtil.valueUnset(this.type)) {
+            invalidParams.add(cUtil.getInvalidTypeParam());
+        }
+
+        return invalidParams;
+    }
+
     public abstract ArrayList<InvalidParameter> getSemanticErrors(ChaincodeStub stub);
+
+    public abstract void ensureIsDroppable(ChaincodeStub stub);
 }
 

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/AbstractAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/AbstractAdmission.java
@@ -1,12 +1,15 @@
 package de.upb.cs.uc4.chaincode.model.admission;
 
 import com.google.gson.annotations.SerializedName;
+import de.upb.cs.uc4.chaincode.model.errors.InvalidParameter;
 import io.swagger.annotations.ApiModelProperty;
+import org.hyperledger.fabric.shim.ChaincodeStub;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Objects;
 
-public class AbstractAdmission {
+public abstract class AbstractAdmission {
     protected static final String DELIMITER = ":";
 
     @SerializedName("admissionId")
@@ -31,7 +34,7 @@ public class AbstractAdmission {
         return this.admissionId;
     }
 
-    public void resetAdmissionId() {}
+    public abstract void resetAdmissionId();
 
     @ApiModelProperty()
     public String getEnrollmentId() {
@@ -55,10 +58,6 @@ public class AbstractAdmission {
     @ApiModelProperty()
     public AdmissionType getType() {
         return this.type;
-    }
-
-    public void setType(AdmissionType type) {
-        this.type = type;
     }
 
     @Override
@@ -104,5 +103,8 @@ public class AbstractAdmission {
         }
         return o.toString().replace("\n", "\n    ");
     }
+
+    public abstract ArrayList<InvalidParameter> getParameterErrors();
+    public abstract ArrayList<InvalidParameter> getSemanticErrors(ChaincodeStub stub);
 }
 

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/AbstractAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/AbstractAdmission.java
@@ -1,4 +1,4 @@
-package de.upb.cs.uc4.chaincode.model;
+package de.upb.cs.uc4.chaincode.model.admission;
 
 import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModelProperty;
@@ -6,23 +6,20 @@ import io.swagger.annotations.ApiModelProperty;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-public class Admission {
-    private static final String DELIMITER = ":";
+public class AbstractAdmission {
+    protected static final String DELIMITER = ":";
 
     @SerializedName("admissionId")
-    private String admissionId;
+    protected String admissionId;
 
     @SerializedName("enrollmentId")
-    private String enrollmentId;
-
-    @SerializedName("courseId")
-    private String courseId;
-
-    @SerializedName("moduleId")
-    private String moduleId;
+    protected String enrollmentId;
 
     @SerializedName("timestamp")
-    private LocalDateTime timestamp;
+    protected LocalDateTime timestamp;
+
+    @SerializedName("type")
+    protected AdmissionType type;
 
     /**
      * Get admissionId
@@ -34,15 +31,8 @@ public class Admission {
         return this.admissionId;
     }
 
-    public void resetAdmissionId() {
-        this.admissionId = this.enrollmentId + Admission.DELIMITER + this.courseId;
-    }
+    public void resetAdmissionId() {}
 
-    /**
-     * Get enrollmentId
-     *
-     * @return enrollmentId
-     **/
     @ApiModelProperty()
     public String getEnrollmentId() {
         return this.enrollmentId;
@@ -53,41 +43,6 @@ public class Admission {
         resetAdmissionId();
     }
 
-    /**
-     * Get courseId
-     *
-     * @return courseId
-     **/
-    @ApiModelProperty()
-    public String getCourseId() {
-        return this.courseId;
-    }
-
-    public void setCourseId(String courseId) {
-        this.courseId = courseId;
-        resetAdmissionId();
-    }
-
-    /**
-     * Get moduleId
-     *
-     * @return moduleId
-     **/
-    @ApiModelProperty()
-    public String getModuleId() {
-        return this.moduleId;
-    }
-
-    public void setModuleId(String moduleId) {
-        this.moduleId = moduleId;
-        resetAdmissionId();
-    }
-
-    /**
-     * Get timestamp
-     *
-     * @return timestamp
-     **/
     @ApiModelProperty()
     public LocalDateTime getTimestamp() {
         return this.timestamp;
@@ -95,7 +50,15 @@ public class Admission {
 
     public void setTimestamp(LocalDateTime timestamp) {
         this.timestamp = timestamp;
-        resetAdmissionId();
+    }
+
+    @ApiModelProperty()
+    public AdmissionType getType() {
+        return this.type;
+    }
+
+    public void setType(AdmissionType type) {
+        this.type = type;
     }
 
     @Override
@@ -106,17 +69,16 @@ public class Admission {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        Admission other = (Admission) o;
+        AbstractAdmission other = (AbstractAdmission) o;
         return Objects.equals(this.admissionId, other.admissionId)
                 && Objects.equals(this.enrollmentId, other.enrollmentId)
-                && Objects.equals(this.courseId, other.courseId)
-                && Objects.equals(this.moduleId, other.moduleId)
-                && Objects.equals(this.timestamp, other.timestamp);
+                && Objects.equals(this.timestamp, other.timestamp)
+                && Objects.equals(this.type, other.type);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.admissionId, this.enrollmentId, this.courseId, this.moduleId, this.timestamp);
+        return Objects.hash(this.admissionId, this.enrollmentId, this.timestamp, this.type);
     }
 
 
@@ -126,9 +88,8 @@ public class Admission {
         sb.append("class Admission {\n");
         sb.append("    admissionId: ").append(toIndentedString(this.admissionId)).append("\n");
         sb.append("    enrollmentId: ").append(toIndentedString(this.enrollmentId)).append("\n");
-        sb.append("    courseId: ").append(toIndentedString(this.courseId)).append("\n");
-        sb.append("    moduleId: ").append(toIndentedString(this.moduleId)).append("\n");
         sb.append("    timestamp: ").append(toIndentedString(this.timestamp)).append("\n");
+        sb.append("    type: ").append(toIndentedString(this.type)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/AdmissionType.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/AdmissionType.java
@@ -1,0 +1,23 @@
+package de.upb.cs.uc4.chaincode.model.admission;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.lang.reflect.Type;
+
+public enum AdmissionType {
+    @SerializedName("Course")
+    COURSE,
+    @SerializedName("Exam")
+    EXAM;
+
+    public Type getAdmissionType() {
+        switch (this) {
+            case COURSE:
+                return CourseAdmission.class;
+            case EXAM:
+                return ExamAdmission.class;
+            default:
+                return AbstractAdmission.class;
+        }
+    }
+}

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/AdmissionType.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/AdmissionType.java
@@ -3,6 +3,9 @@ package de.upb.cs.uc4.chaincode.model.admission;
 import com.google.gson.annotations.SerializedName;
 
 import java.lang.reflect.Type;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
 
 public enum AdmissionType {
     @SerializedName("Course")
@@ -10,7 +13,7 @@ public enum AdmissionType {
     @SerializedName("Exam")
     EXAM;
 
-    public Type getAdmissionType() {
+    public Type valueToType() {
         switch (this) {
             case COURSE:
                 return CourseAdmission.class;

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/CourseAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/CourseAdmission.java
@@ -1,20 +1,20 @@
 package de.upb.cs.uc4.chaincode.model.admission;
 
 import com.google.gson.annotations.SerializedName;
+import de.upb.cs.uc4.chaincode.contract.ContractUtil;
+import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContractUtil;
+import de.upb.cs.uc4.chaincode.model.errors.InvalidParameter;
 import io.swagger.annotations.ApiModelProperty;
+import org.hyperledger.fabric.shim.ChaincodeStub;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Objects;
 
 public class CourseAdmission extends AbstractAdmission {
 
     public CourseAdmission () {
         type = AdmissionType.COURSE;
-    }
-
-    @Override
-    public void setType(AdmissionType type) {
-        this.type = AdmissionType.COURSE;
     }
 
     @SerializedName("courseId")
@@ -98,6 +98,40 @@ public class CourseAdmission extends AbstractAdmission {
             return "null";
         }
         return o.toString().replace("\n", "\n    ");
+    }
+
+    @Override
+    public ArrayList<InvalidParameter> getParameterErrors() {
+        AdmissionContractUtil cUtil = new AdmissionContractUtil();
+        ArrayList<InvalidParameter> invalidparams = new ArrayList<>();
+
+        if (cUtil.valueUnset(this.getEnrollmentId())) {
+            invalidparams.add(cUtil.getEmptyEnrollmentIdParam(cUtil.getErrorPrefix() + "."));
+        }
+        if (cUtil.valueUnset(this.getCourseId())) {
+            invalidparams.add(cUtil.getEmptyInvalidParameter(cUtil.getErrorPrefix() + ".courseId"));
+        }
+        if (cUtil.valueUnset(this.getModuleId())) {
+            invalidparams.add(cUtil.getEmptyInvalidParameter(cUtil.getErrorPrefix() + ".moduleId"));
+        }
+        if (cUtil.valueUnset(this.getTimestamp())) {
+            invalidparams.add(cUtil.getInvalidTimestampParam());
+        }
+
+        return invalidparams;
+    }
+
+    @Override
+    public ArrayList<InvalidParameter> getSemanticErrors(ChaincodeStub stub) {
+        AdmissionContractUtil cUtil = new AdmissionContractUtil();
+        ArrayList<InvalidParameter> invalidParameters = new ArrayList<>();
+
+        if (!cUtil.checkModuleAvailable(stub, this)) {
+            invalidParameters.add(cUtil.getInvalidModuleAvailable("enrollmentId"));
+            invalidParameters.add(cUtil.getInvalidModuleAvailable("moduleId"));
+        }
+
+        return invalidParameters;
     }
 }
 

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/CourseAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/CourseAdmission.java
@@ -61,12 +61,9 @@ public class CourseAdmission extends AbstractAdmission {
             return false;
         }
         CourseAdmission other = (CourseAdmission) o;
-        return Objects.equals(this.admissionId, other.admissionId)
-                && Objects.equals(this.enrollmentId, other.enrollmentId)
-                && Objects.equals(this.courseId, other.courseId)
+        return Objects.equals(this.courseId, other.courseId)
                 && Objects.equals(this.moduleId, other.moduleId)
-                && Objects.equals(this.timestamp, other.timestamp)
-                && Objects.equals(this.type, other.type);
+                && super.equals(o);
     }
 
     @Override

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/CourseAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/CourseAdmission.java
@@ -8,7 +8,14 @@ import java.util.Objects;
 
 public class CourseAdmission extends AbstractAdmission {
 
-    protected final AdmissionType type = AdmissionType.COURSE;
+    public CourseAdmission () {
+        type = AdmissionType.COURSE;
+    }
+
+    @Override
+    public void setType(AdmissionType type) {
+        this.type = AdmissionType.COURSE;
+    }
 
     @SerializedName("courseId")
     protected String courseId;

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/CourseAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/CourseAdmission.java
@@ -103,19 +103,13 @@ public class CourseAdmission extends AbstractAdmission {
     @Override
     public ArrayList<InvalidParameter> getParameterErrors() {
         AdmissionContractUtil cUtil = new AdmissionContractUtil();
-        ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
+        ArrayList<InvalidParameter> invalidParams = super.getParameterErrors();
 
-        if (cUtil.valueUnset(this.getEnrollmentId())) {
-            invalidParams.add(cUtil.getEmptyEnrollmentIdParam(cUtil.getErrorPrefix() + "."));
-        }
         if (cUtil.valueUnset(this.getCourseId())) {
             invalidParams.add(cUtil.getEmptyInvalidParameter(cUtil.getErrorPrefix() + ".courseId"));
         }
         if (cUtil.valueUnset(this.getModuleId())) {
             invalidParams.add(cUtil.getEmptyInvalidParameter(cUtil.getErrorPrefix() + ".moduleId"));
-        }
-        if (cUtil.valueUnset(this.getTimestamp())) {
-            invalidParams.add(cUtil.getInvalidTimestampParam());
         }
 
         return invalidParams;
@@ -133,5 +127,8 @@ public class CourseAdmission extends AbstractAdmission {
 
         return invalidParameters;
     }
+
+    @Override
+    public void ensureIsDroppable(ChaincodeStub stub) {}
 }
 

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/CourseAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/CourseAdmission.java
@@ -1,0 +1,96 @@
+package de.upb.cs.uc4.chaincode.model.admission;
+
+import com.google.gson.annotations.SerializedName;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public class CourseAdmission extends AbstractAdmission {
+
+    protected final AdmissionType type = AdmissionType.COURSE;
+
+    @SerializedName("courseId")
+    protected String courseId;
+
+    @SerializedName("moduleId")
+    protected String moduleId;
+
+    @ApiModelProperty()
+    public String getAdmissionId() {
+        return this.admissionId;
+    }
+
+    public void resetAdmissionId() {
+        this.admissionId = this.enrollmentId + DELIMITER + this.courseId;
+    }
+
+    @ApiModelProperty()
+    public String getCourseId() {
+        return this.courseId;
+    }
+
+    public void setCourseId(String courseId) {
+        this.courseId = courseId;
+        resetAdmissionId();
+    }
+
+    @ApiModelProperty()
+    public String getModuleId() {
+        return this.moduleId;
+    }
+
+    public void setModuleId(String moduleId) {
+        this.moduleId = moduleId;
+        resetAdmissionId();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CourseAdmission other = (CourseAdmission) o;
+        return Objects.equals(this.admissionId, other.admissionId)
+                && Objects.equals(this.enrollmentId, other.enrollmentId)
+                && Objects.equals(this.courseId, other.courseId)
+                && Objects.equals(this.moduleId, other.moduleId)
+                && Objects.equals(this.timestamp, other.timestamp)
+                && Objects.equals(this.type, other.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.admissionId, this.enrollmentId, this.courseId, this.moduleId, this.timestamp, type);
+    }
+
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Admission {\n");
+        sb.append("    admissionId: ").append(toIndentedString(this.admissionId)).append("\n");
+        sb.append("    enrollmentId: ").append(toIndentedString(this.enrollmentId)).append("\n");
+        sb.append("    courseId: ").append(toIndentedString(this.courseId)).append("\n");
+        sb.append("    moduleId: ").append(toIndentedString(this.moduleId)).append("\n");
+        sb.append("    timestamp: ").append(toIndentedString(this.timestamp)).append("\n");
+        sb.append("    type: ").append(toIndentedString(this.type)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/CourseAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/CourseAdmission.java
@@ -103,22 +103,22 @@ public class CourseAdmission extends AbstractAdmission {
     @Override
     public ArrayList<InvalidParameter> getParameterErrors() {
         AdmissionContractUtil cUtil = new AdmissionContractUtil();
-        ArrayList<InvalidParameter> invalidparams = new ArrayList<>();
+        ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
 
         if (cUtil.valueUnset(this.getEnrollmentId())) {
-            invalidparams.add(cUtil.getEmptyEnrollmentIdParam(cUtil.getErrorPrefix() + "."));
+            invalidParams.add(cUtil.getEmptyEnrollmentIdParam(cUtil.getErrorPrefix() + "."));
         }
         if (cUtil.valueUnset(this.getCourseId())) {
-            invalidparams.add(cUtil.getEmptyInvalidParameter(cUtil.getErrorPrefix() + ".courseId"));
+            invalidParams.add(cUtil.getEmptyInvalidParameter(cUtil.getErrorPrefix() + ".courseId"));
         }
         if (cUtil.valueUnset(this.getModuleId())) {
-            invalidparams.add(cUtil.getEmptyInvalidParameter(cUtil.getErrorPrefix() + ".moduleId"));
+            invalidParams.add(cUtil.getEmptyInvalidParameter(cUtil.getErrorPrefix() + ".moduleId"));
         }
         if (cUtil.valueUnset(this.getTimestamp())) {
-            invalidparams.add(cUtil.getInvalidTimestampParam());
+            invalidParams.add(cUtil.getInvalidTimestampParam());
         }
 
-        return invalidparams;
+        return invalidParams;
     }
 
     @Override

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/ExamAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/ExamAdmission.java
@@ -1,0 +1,75 @@
+package de.upb.cs.uc4.chaincode.model.admission;
+
+import com.google.gson.annotations.SerializedName;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Objects;
+
+public class ExamAdmission extends AbstractAdmission {
+
+    protected final AdmissionType type = AdmissionType.EXAM;
+
+    @SerializedName("examId")
+    private String examId;
+
+    public void resetAdmissionId() {
+        this.admissionId = this.enrollmentId + DELIMITER + this.examId;
+    }
+
+    @ApiModelProperty()
+    public String getExamId() {
+        return this.examId;
+    }
+
+    public void setExamId(String examId) {
+        this.examId = examId;
+        resetAdmissionId();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ExamAdmission other = (ExamAdmission) o;
+        return Objects.equals(this.admissionId, other.admissionId)
+                && Objects.equals(this.enrollmentId, other.enrollmentId)
+                && Objects.equals(this.examId, other.examId)
+                && Objects.equals(this.timestamp, other.timestamp)
+                && Objects.equals(this.type, other.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.admissionId, this.enrollmentId, this.examId, this.timestamp);
+    }
+
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class Admission {\n");
+        sb.append("    admissionId: ").append(toIndentedString(this.admissionId)).append("\n");
+        sb.append("    enrollmentId: ").append(toIndentedString(this.enrollmentId)).append("\n");
+        sb.append("    courseId: ").append(toIndentedString(this.examId)).append("\n");
+        sb.append("    timestamp: ").append(toIndentedString(this.timestamp)).append("\n");
+        sb.append("    type: ").append(toIndentedString(this.type)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}
+

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/ExamAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/ExamAdmission.java
@@ -1,19 +1,18 @@
 package de.upb.cs.uc4.chaincode.model.admission;
 
 import com.google.gson.annotations.SerializedName;
+import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContractUtil;
+import de.upb.cs.uc4.chaincode.model.errors.InvalidParameter;
 import io.swagger.annotations.ApiModelProperty;
+import org.hyperledger.fabric.shim.ChaincodeStub;
 
+import java.util.ArrayList;
 import java.util.Objects;
 
 public class ExamAdmission extends AbstractAdmission {
 
     public ExamAdmission () {
         type = AdmissionType.EXAM;
-    }
-
-    @Override
-    public void setType(AdmissionType type) {
-        this.type = AdmissionType.EXAM;
     }
 
     @SerializedName("examId")
@@ -77,6 +76,30 @@ public class ExamAdmission extends AbstractAdmission {
             return "null";
         }
         return o.toString().replace("\n", "\n    ");
+    }
+
+
+    @Override
+    public ArrayList<InvalidParameter> getParameterErrors() {
+        AdmissionContractUtil cUtil = new AdmissionContractUtil();
+        ArrayList<InvalidParameter> invalidparams = new ArrayList<>();
+
+        if (cUtil.valueUnset(this.getEnrollmentId())) {
+            invalidparams.add(cUtil.getEmptyEnrollmentIdParam(cUtil.getErrorPrefix() + "."));
+        }
+
+        // TODO analogous to CourseAdmission
+
+        return invalidparams;
+    }
+
+    public ArrayList<InvalidParameter> getSemanticErrors(ChaincodeStub stub) {
+        AdmissionContractUtil cUtil = new AdmissionContractUtil();
+        ArrayList<InvalidParameter> invalidParameters = new ArrayList<>();
+
+        // TODO
+
+        return invalidParameters;
     }
 }
 

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/ExamAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/ExamAdmission.java
@@ -7,7 +7,14 @@ import java.util.Objects;
 
 public class ExamAdmission extends AbstractAdmission {
 
-    protected final AdmissionType type = AdmissionType.EXAM;
+    public ExamAdmission () {
+        type = AdmissionType.EXAM;
+    }
+
+    @Override
+    public void setType(AdmissionType type) {
+        this.type = AdmissionType.EXAM;
+    }
 
     @SerializedName("examId")
     private String examId;

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/ExamAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/ExamAdmission.java
@@ -82,24 +82,27 @@ public class ExamAdmission extends AbstractAdmission {
     @Override
     public ArrayList<InvalidParameter> getParameterErrors() {
         AdmissionContractUtil cUtil = new AdmissionContractUtil();
-        ArrayList<InvalidParameter> invalidparams = new ArrayList<>();
+        ArrayList<InvalidParameter> invalidParams = super.getParameterErrors();
 
-        if (cUtil.valueUnset(this.getEnrollmentId())) {
-            invalidparams.add(cUtil.getEmptyEnrollmentIdParam(cUtil.getErrorPrefix() + "."));
+        if (cUtil.valueUnset(this.examId)) {
+            invalidParams.add(cUtil.getEmptyInvalidParameter(cUtil.getErrorPrefix() + ".examId"));
         }
 
-        // TODO analogous to CourseAdmission
-
-        return invalidparams;
+        return invalidParams;
     }
 
     public ArrayList<InvalidParameter> getSemanticErrors(ChaincodeStub stub) {
         AdmissionContractUtil cUtil = new AdmissionContractUtil();
         ArrayList<InvalidParameter> invalidParameters = new ArrayList<>();
 
-        // TODO
+        // TODO add remaining checks once all necessary contracts available
 
         return invalidParameters;
+    }
+
+    @Override
+    public void ensureIsDroppable(ChaincodeStub stub) {
+        // TODO check if corresponding exam is droppable (otherwise throw error)
     }
 }
 

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/ExamAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/ExamAdmission.java
@@ -41,11 +41,8 @@ public class ExamAdmission extends AbstractAdmission {
             return false;
         }
         ExamAdmission other = (ExamAdmission) o;
-        return Objects.equals(this.admissionId, other.admissionId)
-                && Objects.equals(this.enrollmentId, other.enrollmentId)
-                && Objects.equals(this.examId, other.examId)
-                && Objects.equals(this.timestamp, other.timestamp)
-                && Objects.equals(this.type, other.type);
+        return Objects.equals(this.examId, other.examId)
+                && super.equals(o);
     }
 
     @Override

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/AdmissionContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/AdmissionContractTest.java
@@ -1,5 +1,6 @@
 package de.upb.cs.uc4.chaincode;
 
+import com.google.gson.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContract;
 import de.upb.cs.uc4.chaincode.model.*;
 import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContractUtil;
@@ -10,6 +11,8 @@ import org.hyperledger.fabric.contract.Context;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.function.Executable;
 
+import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -119,7 +122,7 @@ public final class AdmissionContractTest extends TestCreationBase {
         return () -> {
             Context ctx = TestUtil.buildContext(AdmissionContract.contractName, AdmissionContract.transactionNameGetAdmissions, setup, input, ids);
 
-            String getResult = contract.getAdmissions(ctx, input.get(0), input.get(1), input.get(2));
+            String getResult = contract.getCourseAdmissions(ctx, input.get(0), input.get(1), input.get(2));
             assertThat(getResult).isEqualTo(compare.get(0));
         };
     }

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/AdmissionContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/AdmissionContractTest.java
@@ -1,6 +1,5 @@
 package de.upb.cs.uc4.chaincode;
 
-import com.google.gson.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContract;
 import de.upb.cs.uc4.chaincode.model.*;
 import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContractUtil;
@@ -11,8 +10,6 @@ import org.hyperledger.fabric.contract.Context;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.function.Executable;
 
-import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -120,7 +117,7 @@ public final class AdmissionContractTest extends TestCreationBase {
             List<String> ids
     ) {
         return () -> {
-            Context ctx = TestUtil.buildContext(AdmissionContract.contractName, AdmissionContract.transactionNameGetAdmissions, setup, input, ids);
+            Context ctx = TestUtil.buildContext(AdmissionContract.contractName, AdmissionContract.transactionNameGetCourseAdmissions, setup, input, ids);
 
             String getResult = contract.getCourseAdmissions(ctx, input.get(0), input.get(1), input.get(2));
             assertThat(getResult).isEqualTo(compare.get(0));

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/AdmissionContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/AdmissionContractTest.java
@@ -1,12 +1,10 @@
 package de.upb.cs.uc4.chaincode;
 
-import de.upb.cs.uc4.chaincode.contract.certificate.CertificateContract;
-import de.upb.cs.uc4.chaincode.contract.operation.OperationContract;
 import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContract;
-import de.upb.cs.uc4.chaincode.mock.MockChaincodeStub;
 import de.upb.cs.uc4.chaincode.model.*;
 import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContractUtil;
 import de.upb.cs.uc4.chaincode.helper.GsonWrapper;
+import de.upb.cs.uc4.chaincode.model.admission.CourseAdmission;
 import de.upb.cs.uc4.chaincode.util.TestUtil;
 import org.hyperledger.fabric.contract.Context;
 import org.junit.jupiter.api.DynamicTest;
@@ -61,8 +59,8 @@ public final class AdmissionContractTest extends TestCreationBase {
             String addResult = contract.addAdmission(ctx, input.get(0));
 
             assertThat(addResult).isEqualTo(compare.get(0));
-            Admission compareAdmission = GsonWrapper.fromJson(compare.get(0), Admission.class);
-            Admission ledgerAdmission = cUtil.getState(ctx.getStub(), compareAdmission.getAdmissionId(), Admission.class);
+            CourseAdmission compareAdmission = GsonWrapper.fromJson(compare.get(0), CourseAdmission.class);
+            CourseAdmission ledgerAdmission = cUtil.getState(ctx.getStub(), compareAdmission.getAdmissionId(), CourseAdmission.class);
             assertThat(ledgerAdmission).isEqualTo(compareAdmission);
             assertThat(ledgerAdmission.toString()).isEqualTo(compareAdmission.toString());
         };
@@ -93,7 +91,7 @@ public final class AdmissionContractTest extends TestCreationBase {
             String dropResult = contract.dropAdmission(ctx, input.get(0));
 
             assertThat(dropResult).isEqualTo(compare.get(0));
-            List<Admission> ledgerState = cUtil.getAllStates(ctx.getStub(), Admission.class);
+            List<CourseAdmission> ledgerState = cUtil.getAllStates(ctx.getStub(), CourseAdmission.class);
             assertThat(ledgerState).allMatch(item -> !(item.getAdmissionId().equals(input.get(0))));
         };
     }

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/AdmissionContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/AdmissionContractTest.java
@@ -40,8 +40,10 @@ public final class AdmissionContractTest extends TestCreationBase {
                 return DynamicTest.dynamicTest(testName, dropAdmissionSuccessTest(setup, input, compare, ids));
             case "dropAdmission_FAILURE":
                 return DynamicTest.dynamicTest(testName, dropAdmissionFailureTest(setup, input, compare, ids));
-            case "getAdmissions_SUCCESS":
-                return DynamicTest.dynamicTest(testName, getAdmissionsSuccessTest(setup, input, compare, ids));
+            case "getCourseAdmissions_SUCCESS":
+                return DynamicTest.dynamicTest(testName, getCourseAdmissionsSuccessTest(setup, input, compare, ids));
+            case "getExamAdmissions_SUCCESS":
+                return DynamicTest.dynamicTest(testName, getExamAdmissionsSuccessTest(setup, input, compare, ids));
             default:
                 throw new RuntimeException("Test " + testName + " of type " + testType + " could not be matched.");
         }
@@ -110,7 +112,7 @@ public final class AdmissionContractTest extends TestCreationBase {
         };
     }
 
-    private Executable getAdmissionsSuccessTest(
+    private Executable getCourseAdmissionsSuccessTest(
             JsonIOTestSetup setup,
             List<String> input,
             List<String> compare,
@@ -120,6 +122,20 @@ public final class AdmissionContractTest extends TestCreationBase {
             Context ctx = TestUtil.buildContext(AdmissionContract.contractName, AdmissionContract.transactionNameGetCourseAdmissions, setup, input, ids);
 
             String getResult = contract.getCourseAdmissions(ctx, input.get(0), input.get(1), input.get(2));
+            assertThat(getResult).isEqualTo(compare.get(0));
+        };
+    }
+
+    private Executable getExamAdmissionsSuccessTest(
+            JsonIOTestSetup setup,
+            List<String> input,
+            List<String> compare,
+            List<String> ids
+    ) {
+        return () -> {
+            Context ctx = TestUtil.buildContext(AdmissionContract.contractName, AdmissionContract.transactionNameGetExamAdmissions, setup, input, ids);
+
+            String getResult = contract.getExamAdmissions(ctx, input.get(0), input.get(1), input.get(2));
             assertThat(getResult).isEqualTo(compare.get(0));
         };
     }

--- a/UC4-chaincode/src/test/resources/test_configs/admission_contract/AddAdmissionTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/admission_contract/AddAdmissionTestIO.json
@@ -234,6 +234,36 @@
     ]
   },
   {
+    "name": "addNonExistingExamAdmission_EmptyExamId",
+    "type": "addAdmission_FAILURE",
+    "ids": [
+      "User1",
+      "0000002"
+    ],
+    "setup": {},
+    "input": [
+      {
+        "examId": "",
+        "admissionId": "",
+        "enrollmentId": "0000001",
+        "timestamp": "2020-12-31T23:59:59",
+        "type": "Exam"
+      }
+    ],
+    "compare": [
+      {
+        "type": "HLUnprocessableEntity",
+        "title": "The following parameters do not conform to the specified format",
+        "invalidParams": [
+          {
+            "name": "admission.examId",
+            "reason": "The given parameter must not be empty"
+          }
+        ]
+      }
+    ]
+  },
+  {
     "name": "addNonExistingAdmission_EmptyParam_CourseId",
     "type": "addAdmission_FAILURE",
     "ids": [

--- a/UC4-chaincode/src/test/resources/test_configs/admission_contract/AddAdmissionTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/admission_contract/AddAdmissionTestIO.json
@@ -54,16 +54,18 @@
         "enrollmentId": "0000001",
         "courseId": "C.1",
         "moduleId": "M.1",
-        "timestamp": "2020-12-31T23:59:59"
+        "timestamp": "2020-12-31T23:59:59",
+        "type": "Course"
       }
     ],
     "compare": [
       {
-        "admissionId": "0000001:C.1",
-        "enrollmentId": "0000001",
         "courseId": "C.1",
         "moduleId": "M.1",
-        "timestamp": "2020-12-31T23:59:59"
+        "admissionId": "0000001:C.1",
+        "enrollmentId": "0000001",
+        "timestamp": "2020-12-31T23:59:59",
+        "type": "Course"
       }
     ]
   },
@@ -169,7 +171,8 @@
         "enrollmentId": "",
         "courseId": "C.1",
         "moduleId": "M.1",
-        "timestamp": "2020-12-31T23:59:59"
+        "timestamp": "2020-12-31T23:59:59",
+        "type": "Course"
       }
     ],
     "compare": [
@@ -239,7 +242,8 @@
         "enrollmentId": "0000003",
         "courseId": "",
         "moduleId": "M.1",
-        "timestamp": "2020-12-31T23:59:59"
+        "timestamp": "2020-12-31T23:59:59",
+        "type": "Course"
       }
     ],
     "compare": [
@@ -301,7 +305,8 @@
         "enrollmentId": "0000004",
         "courseId": "C.1",
         "moduleId": "",
-        "timestamp": "2020-12-31T23:59:59"
+        "timestamp": "2020-12-31T23:59:59",
+        "type": "Course"
       }
     ],
     "compare": [
@@ -371,7 +376,8 @@
         "enrollmentId": "0000005",
         "courseId": "C.1",
         "moduleId": "M.1",
-        "timestamp": ""
+        "timestamp": "",
+        "type": "Course"
       }
     ],
     "compare": [
@@ -433,7 +439,8 @@
         "enrollmentId": "0000006",
         "courseId": "C.1",
         "moduleId": "M.1",
-        "timestamp": "2020-12-31-23:59:59"
+        "timestamp": "2020-12-31-23:59:59",
+        "type": "Course"
       }
     ],
     "compare": [
@@ -495,7 +502,8 @@
         "enrollmentId": "0000007",
         "courseId": "C.1",
         "moduleId": "M.1",
-        "timestamp": "2020-12-31T12:59:59"
+        "timestamp": "2020-12-31T12:59:59",
+        "type": "Course"
       }
     ],
     "compare": [
@@ -561,7 +569,8 @@
         "enrollmentId": "0000009",
         "courseId": "C.1",
         "moduleId": "M.3",
-        "timestamp": "2020-12-31T12:59:59"
+        "timestamp": "2020-12-31T12:59:59",
+        "type": "Course"
       }
     ],
     "compare": [
@@ -627,7 +636,8 @@
           "enrollmentId": "0000008",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T12:59:59"
+          "timestamp": "2020-12-31T12:59:59",
+          "type": "Course"
         }
       ]
     },
@@ -637,7 +647,8 @@
         "enrollmentId": "0000008",
         "courseId": "C.1",
         "moduleId": "M.1",
-        "timestamp": "2020-12-31T12:59:59"
+        "timestamp": "2020-12-31T12:59:59",
+        "type": "Course"
       }
     ],
     "compare": [

--- a/UC4-chaincode/src/test/resources/test_configs/admission_contract/AddAdmissionTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/admission_contract/AddAdmissionTestIO.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "addNonExistingAdmission",
+    "name": "addNonExistingCourseAdmission",
     "type": "addAdmission_SUCCESS",
     "ids": [
       "User1",
@@ -66,6 +66,43 @@
         "enrollmentId": "0000001",
         "timestamp": "2020-12-31T23:59:59",
         "type": "Course"
+      }
+    ]
+  },
+  {
+    "name": "addNonExistingExamAdmission",
+    "type": "addAdmission_SUCCESS",
+    "ids": [
+      "User1",
+      "0000001"
+    ],
+    "setup": {
+      "groupContract": [
+        "System",
+        {
+          "groupId": "System",
+          "userList": [
+            "User1"
+          ]
+        }
+      ]
+    },
+    "input": [
+      {
+        "admissionId": "",
+        "enrollmentId": "0000001",
+        "examId": "ExampleCourse:M.1:WrittenExam:2021-02-16T10:00:00",
+        "timestamp": "2020-12-31T23:59:59",
+        "type": "Exam"
+      }
+    ],
+    "compare": [
+      {
+        "examId": "ExampleCourse:M.1:WrittenExam:2021-02-16T10:00:00",
+        "admissionId": "0000001:ExampleCourse:M.1:WrittenExam:2021-02-16T10:00:00",
+        "enrollmentId": "0000001",
+        "timestamp": "2020-12-31T23:59:59",
+        "type": "Exam"
       }
     ]
   },

--- a/UC4-chaincode/src/test/resources/test_configs/admission_contract/DropAdmissionTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/admission_contract/DropAdmissionTestIO.json
@@ -45,7 +45,8 @@
           "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ],
       "groupContract": [
@@ -111,7 +112,8 @@
           "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     },
@@ -171,7 +173,8 @@
           "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     },

--- a/UC4-chaincode/src/test/resources/test_configs/admission_contract/GetAdmissionTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/admission_contract/GetAdmissionTestIO.json
@@ -1,7 +1,7 @@
 [
   {
-    "name": "getExistingAdmissions",
-    "type": "getAdmissions_SUCCESS",
+    "name": "getExistingCourseAdmissions",
+    "type": "getCourseAdmissions_SUCCESS",
     "ids": [
       "User1",
       "0000001"
@@ -143,6 +143,14 @@
           "moduleId": "MM.1",
           "timestamp": "2020-12-31T23:59:59",
           "type": "Course"
+        },
+        "0000001:ExampleCourse:M.1:WrittenExam:2021-02-16T10:00:00",
+        {
+          "examId": "ExampleCourse:M.1:WrittenExam:2021-02-16T10:00:00",
+          "admissionId": "0000001:ExampleCourse:M.1:WrittenExam:2021-02-16T10:00:00",
+          "enrollmentId": "0000001",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Exam"
         }
       ]
     },
@@ -165,8 +173,61 @@
     ]
   },
   {
+    "name": "getExistingExamAdmissions",
+    "type": "getExamAdmissions_SUCCESS",
+    "ids": [
+      "User1"
+    ],
+    "setup": {
+      "groupContract": [
+        "System",
+        {
+          "groupId": "System",
+          "userList": [
+            "User1"
+          ]
+        }
+      ],
+      "admissionContract": [
+        "0000001:C.1",
+        {
+          "admissionId": "0000001:C.1",
+          "enrollmentId": "0000001",
+          "courseId": "C.1",
+          "moduleId": "M.1",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
+        },
+        "0000001:ExampleCourse:M.1:WrittenExam:2021-02-16T10:00:00",
+        {
+          "examId": "ExampleCourse:M.1:WrittenExam:2021-02-16T10:00:00",
+          "admissionId": "0000001:ExampleCourse:M.1:WrittenExam:2021-02-16T10:00:00",
+          "enrollmentId": "0000001",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Exam"
+        }
+      ]
+    },
+    "input": [
+      [],
+      "0000001",
+      []
+    ],
+    "compare": [
+      [
+        {
+          "examId": "ExampleCourse:M.1:WrittenExam:2021-02-16T10:00:00",
+          "admissionId": "0000001:ExampleCourse:M.1:WrittenExam:2021-02-16T10:00:00",
+          "enrollmentId": "0000001",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Exam"
+        }
+      ]
+    ]
+  },
+  {
     "name": "getExistingAdmissions_Multiple",
-    "type": "getAdmissions_SUCCESS",
+    "type": "getCourseAdmissions_SUCCESS",
     "ids": [
       "User1",
       "0000002"
@@ -339,7 +400,7 @@
   },
   {
     "name": "getExistingAdmissions_Empty",
-    "type": "getAdmissions_SUCCESS",
+    "type": "getCourseAdmissions_SUCCESS",
     "ids": [
       "User1",
       "0000003"
@@ -495,7 +556,7 @@
   },
   {
     "name": "getExistingAdmissions_CourseId",
-    "type": "getAdmissions_SUCCESS",
+    "type": "getCourseAdmissions_SUCCESS",
     "ids": [
       "User1",
       "0000003"
@@ -668,7 +729,7 @@
   },
   {
     "name": "getExistingAdmissions_CourseId_2",
-    "type": "getAdmissions_SUCCESS",
+    "type": "getCourseAdmissions_SUCCESS",
     "ids": [
       "User1",
       "0000003"
@@ -833,7 +894,7 @@
   },
   {
     "name": "getExistingAdmissions_CourseId_Empty",
-    "type": "getAdmissions_SUCCESS",
+    "type": "getCourseAdmissions_SUCCESS",
     "ids": [
       "User1",
       "0000003"
@@ -989,7 +1050,7 @@
   },
   {
     "name": "getExistingAdmissions_ModuleId",
-    "type": "getAdmissions_SUCCESS",
+    "type": "getCourseAdmissions_SUCCESS",
     "ids": [
       "User1",
       "0000003"
@@ -1177,7 +1238,7 @@
   },
   {
     "name": "getExistingAdmissions_ModuleId_CourseId",
-    "type": "getAdmissions_SUCCESS",
+    "type": "getCourseAdmissions_SUCCESS",
     "ids": [
       "User1",
       "0000003"
@@ -1357,7 +1418,7 @@
   },
   {
     "name": "getExistingAdmissions_ModuleId_EnrollmentId",
-    "type": "getAdmissions_SUCCESS",
+    "type": "getCourseAdmissions_SUCCESS",
     "ids": [
       "User1",
       "0000003"
@@ -1537,7 +1598,7 @@
   },
   {
     "name": "getExistingAdmissions_CourseId_EnrollmentId",
-    "type": "getAdmissions_SUCCESS",
+    "type": "getCourseAdmissions_SUCCESS",
     "ids": [
       "User1",
       "0000003"
@@ -1717,7 +1778,7 @@
   },
   {
     "name": "getExistingAdmissions_NoFilter",
-    "type": "getAdmissions_SUCCESS",
+    "type": "getCourseAdmissions_SUCCESS",
     "ids": [
       "User1",
       "0000003"

--- a/UC4-chaincode/src/test/resources/test_configs/admission_contract/GetAdmissionTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/admission_contract/GetAdmissionTestIO.json
@@ -123,7 +123,8 @@
           "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.1",
         {
@@ -131,7 +132,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.1",
           "moduleId": "F.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.2",
         {
@@ -139,7 +141,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.2",
           "moduleId": "MM.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     },
@@ -151,11 +154,12 @@
     "compare": [
       [
         {
-          "admissionId": "0000001:C.1",
-          "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "admissionId": "0000001:C.1",
+          "enrollmentId": "0000001",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     ]
@@ -284,7 +288,8 @@
           "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.1",
         {
@@ -292,7 +297,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.1",
           "moduleId": "F.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.2",
         {
@@ -300,7 +306,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.2",
           "moduleId": "MM.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     },
@@ -312,18 +319,20 @@
     "compare": [
       [
         {
-          "admissionId": "0000002:C.1",
-          "enrollmentId": "0000002",
           "courseId": "C.1",
           "moduleId": "F.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "admissionId": "0000002:C.1",
+          "enrollmentId": "0000002",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         {
-          "admissionId": "0000002:C.2",
-          "enrollmentId": "0000002",
           "courseId": "C.2",
           "moduleId": "MM.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "admissionId": "0000002:C.2",
+          "enrollmentId": "0000002",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     ]
@@ -452,7 +461,8 @@
           "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.1",
         {
@@ -460,7 +470,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.1",
           "moduleId": "F.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.2",
         {
@@ -468,7 +479,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.2",
           "moduleId": "MM.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     },
@@ -605,7 +617,8 @@
           "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.1",
         {
@@ -613,7 +626,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.1",
           "moduleId": "F.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.2",
         {
@@ -621,7 +635,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.2",
           "moduleId": "MM.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     },
@@ -633,18 +648,20 @@
     "compare": [
       [
         {
-          "admissionId": "0000001:C.1",
-          "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "admissionId": "0000001:C.1",
+          "enrollmentId": "0000001",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         {
-          "admissionId": "0000002:C.1",
-          "enrollmentId": "0000002",
           "courseId": "C.1",
           "moduleId": "F.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "admissionId": "0000002:C.1",
+          "enrollmentId": "0000002",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     ]
@@ -773,7 +790,8 @@
           "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.1",
         {
@@ -781,7 +799,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.1",
           "moduleId": "F.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.2",
         {
@@ -789,7 +808,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.2",
           "moduleId": "MM.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     },
@@ -801,11 +821,12 @@
     "compare": [
       [
         {
-          "admissionId": "0000002:C.2",
-          "enrollmentId": "0000002",
           "courseId": "C.2",
           "moduleId": "MM.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "admissionId": "0000002:C.2",
+          "enrollmentId": "0000002",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     ]
@@ -934,7 +955,8 @@
           "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.1",
         {
@@ -942,7 +964,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.1",
           "moduleId": "F.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.2",
         {
@@ -950,7 +973,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.2",
           "moduleId": "MM.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     },
@@ -1093,7 +1117,8 @@
           "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.1",
         {
@@ -1101,7 +1126,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.1",
           "moduleId": "F.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.2",
         {
@@ -1109,7 +1135,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.2",
           "moduleId": "MM.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.3",
         {
@@ -1117,7 +1144,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.3",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     },
@@ -1129,18 +1157,20 @@
     "compare": [
       [
         {
-          "admissionId": "0000001:C.1",
-          "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "admissionId": "0000001:C.1",
+          "enrollmentId": "0000001",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         {
-          "admissionId": "0000002:C.3",
-          "enrollmentId": "0000002",
           "courseId": "C.3",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "admissionId": "0000002:C.3",
+          "enrollmentId": "0000002",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     ]
@@ -1275,7 +1305,8 @@
           "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.1",
         {
@@ -1283,7 +1314,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.1",
           "moduleId": "F.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.2",
         {
@@ -1291,7 +1323,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.2",
           "moduleId": "MM.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.3",
         {
@@ -1299,7 +1332,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.3",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     },
@@ -1311,11 +1345,12 @@
     "compare": [
       [
         {
-          "admissionId": "0000002:C.3",
-          "enrollmentId": "0000002",
           "courseId": "C.3",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "admissionId": "0000002:C.3",
+          "enrollmentId": "0000002",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     ]
@@ -1450,7 +1485,8 @@
           "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.1",
         {
@@ -1458,7 +1494,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.1",
           "moduleId": "F.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.2",
         {
@@ -1466,7 +1503,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.2",
           "moduleId": "MM.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.3",
         {
@@ -1474,7 +1512,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.3",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     },
@@ -1486,11 +1525,12 @@
     "compare": [
       [
         {
-          "admissionId": "0000001:C.1",
-          "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "admissionId": "0000001:C.1",
+          "enrollmentId": "0000001",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     ]
@@ -1625,7 +1665,8 @@
           "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.1",
         {
@@ -1633,7 +1674,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.1",
           "moduleId": "F.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.2",
         {
@@ -1641,7 +1683,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.2",
           "moduleId": "MM.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.3",
         {
@@ -1649,7 +1692,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.3",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     },
@@ -1661,11 +1705,12 @@
     "compare": [
       [
         {
-          "admissionId": "0000001:C.1",
-          "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "admissionId": "0000001:C.1",
+          "enrollmentId": "0000001",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     ]
@@ -1794,7 +1839,8 @@
           "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.1",
         {
@@ -1802,7 +1848,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.1",
           "moduleId": "F.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         "0000002:C.2",
         {
@@ -1810,7 +1857,8 @@
           "enrollmentId": "0000002",
           "courseId": "C.2",
           "moduleId": "MM.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     },
@@ -1822,25 +1870,28 @@
     "compare": [
       [
         {
-          "admissionId": "0000001:C.1",
-          "enrollmentId": "0000001",
           "courseId": "C.1",
           "moduleId": "M.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "admissionId": "0000001:C.1",
+          "enrollmentId": "0000001",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         {
-          "admissionId": "0000002:C.1",
-          "enrollmentId": "0000002",
           "courseId": "C.1",
           "moduleId": "F.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "admissionId": "0000002:C.1",
+          "enrollmentId": "0000002",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         },
         {
-          "admissionId": "0000002:C.2",
-          "enrollmentId": "0000002",
           "courseId": "C.2",
           "moduleId": "MM.1",
-          "timestamp": "2020-12-31T23:59:59"
+          "admissionId": "0000002:C.2",
+          "enrollmentId": "0000002",
+          "timestamp": "2020-12-31T23:59:59",
+          "type": "Course"
         }
       ]
     ]


### PR DESCRIPTION
### Reason for this PR
- admission contract should support both CourseAdmissions and ExamAdmissions

### Changes in this PR
- added AbstractAdmission model
- added ExamAdmission model
- extended GsonWrapper to deserialize AbstractAdmissions to subtype given by type field
- renamed getAdmissions to getCourseAdmissions
- added getExamAdmissions
- refactored how transactions pass their arguments to utility methods, as consistency is often required

### Missing before feature completion
- [ ] add admission checks related to ExamCotract
  - [ ] add check, if exam exists
  - [ ] add check, if student admitted to course related to the exam
  - [ ] add check, if an exam is droppable
  - [ ] add check, if dropping student is admitted to the exam