### PR TITLE
Feature/exam admission semantic checks

### DIFF
--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/ExamAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/ExamAdmission.java
@@ -2,6 +2,7 @@ package de.upb.cs.uc4.chaincode.model.admission;
 
 import com.google.gson.annotations.SerializedName;
 import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContractUtil;
+import de.upb.cs.uc4.chaincode.contract.exam.ExamContractUtil;
 import de.upb.cs.uc4.chaincode.model.errors.InvalidParameter;
 import io.swagger.annotations.ApiModelProperty;
 import org.hyperledger.fabric.shim.ChaincodeStub;
@@ -92,7 +93,24 @@ public class ExamAdmission extends AbstractAdmission {
         AdmissionContractUtil cUtil = new AdmissionContractUtil();
         ArrayList<InvalidParameter> invalidParameters = super.getSemanticErrors(stub);
 
-        // TODO add remaining checks once all necessary contracts available
+        if (!cUtil.checkExamExists(stub, this)) {
+            invalidParameters.add(cUtil.getAdmissionExamNotExistsParam());
+        }
+        if (!cUtil.checkExamAvailableForStudent(stub, this)) {
+            invalidParameters.add(cUtil.getAdmissionExamNotAvailableParam("enrollmentId"));
+            invalidParameters.add(cUtil.getAdmissionExamNotAvailableParam("examId"));
+        }
+        if (!cUtil.checkExamAdmissionNotAlreadyExists(stub, this)) {
+            invalidParameters.add(cUtil.getAdmissionAlreadyExistsParam("enrollmentId"));
+            invalidParameters.add(cUtil.getAdmissionAlreadyExistsParam("examId"));
+        }
+        if (!cUtil.checkCourseAdmissionExists(stub, this)) {
+            invalidParameters.add(cUtil.getCourseAdmissionNotExistsParam("enrollmentId"));
+            invalidParameters.add(cUtil.getCourseAdmissionNotExistsParam("examId"));
+        }
+        if (!cUtil.checkExamAdmittable(stub, this)) {
+            invalidParameters.add(cUtil.getAdmissionNotPossibleParam());
+        }
 
         return invalidParameters;
     }

--- a/UC4-chaincode/src/test/resources/test_configs/admission_contract/AddAdmissionTestIO.json
+++ b/UC4-chaincode/src/test/resources/test_configs/admission_contract/AddAdmissionTestIO.json
@@ -77,6 +77,44 @@
       "0000001"
     ],
     "setup": {
+      "admissionContract": [
+        "0000001:C.1",
+        {
+          "admissionId": "0000001:C.1",
+          "enrollmentId": "0000001",
+          "courseId": "C.1",
+          "moduleId": "M.1",
+          "timestamp": "2020-12-31T23:59:59.000Z",
+          "type": "Course"
+        }
+      ],
+      "examContract": [
+        "ExampleCourse:M.1:Written Exam:2022-02-12T10:00:00Z",
+        {
+          "examId": "ExampleCourse:M.1:Written Exam:2022-02-12T10:00:00Z",
+          "courseId": "C.1",
+          "lecturerEnrollmentId": "lecturer",
+          "moduleId": "M.1",
+          "type": "Written Exam",
+          "date": "2022-02-12T10:00:00Z",
+          "ects": 3,
+          "admittableUntil": "2022-01-30T23:59:59.000Z",
+          "droppableUntil": "2022-01-31T23:59:59.000Z"
+        }
+      ],
+      "examinationRegulationContract": [
+        "Computer Science",
+        {
+          "name": "Computer Science",
+          "active": true,
+          "modules": [
+            {
+              "id":"M.1",
+              "name": "Module1"
+            }
+          ]
+        }
+      ],
       "groupContract": [
         "System",
         {
@@ -105,15 +143,15 @@
       {
         "admissionId": "",
         "enrollmentId": "0000001",
-        "examId": "ExampleCourse:M.1:WrittenExam:2021-02-16T10:00:00Z",
-        "timestamp": "2020-12-31T23:59:59Z",
+        "examId": "ExampleCourse:M.1:Written Exam:2022-02-12T10:00:00Z",
+        "timestamp": "2021-01-30T23:59:59.000Z",
         "type": "Exam"
       }
     ],
     "compare": [
       {
-        "examId": "ExampleCourse:M.1:WrittenExam:2021-02-16T10:00:00Z",
-        "admissionId": "0000001:ExampleCourse:M.1:WrittenExam:2021-02-16T10:00:00Z",
+        "examId": "ExampleCourse:M.1:Written Exam:2022-02-12T10:00:00Z",
+        "admissionId": "0000001:ExampleCourse:M.1:Written Exam:2022-02-12T10:00:00Z",
         "enrollmentId": "0000001",
         "timestamp": "1970-01-01T00:00:00Z",
         "type": "Exam"
@@ -287,6 +325,10 @@
           {
             "name": "admission.examId",
             "reason": "The given parameter must not be empty"
+          },
+          {
+            "name":"admission.examId",
+            "reason":"The exam you are trying to admit for does not exist."
           }
         ]
       }
@@ -636,13 +678,54 @@
             "User1"
           ]
         }
+      ],
+      "examContract": [
+        "ExampleCourse:M.1:WrittenExam:2022-02-12T10:00:00Z",
+        {
+          "examId": "ExampleCourse:M.1:WrittenExam:2022-02-12T10:00:00Z",
+          "courseId": "ExampleCourse",
+          "lecturerEnrollmentId": "lecturer",
+          "moduleId": "M.1",
+          "type": "Written Exam",
+          "date": "2022-02-12T10:00:00Z",
+          "ects": 3,
+          "admittableUntil": "2022-01-30T23:59:59.000Z",
+          "droppableUntil": "2022-01-31T23:59:59.000Z"
+        }
+      ],
+      "examinationRegulationContract": [
+        "Computer Science",
+        {
+          "name": "Computer Science",
+          "active": true,
+          "modules": [
+            {
+              "id":"M.1",
+              "name": "Module1"
+            }
+          ]
+        }
+      ],
+      "matriculationDataContract": [
+        "0000001",
+        {
+          "enrollmentId": "0000001",
+          "matriculationStatus": [
+            {
+              "fieldOfStudy": "Computer Science",
+              "semesters": [
+                "WS2018/19"
+              ]
+            }
+          ]
+        }
       ]
     },
     "input": [
       {
         "admissionId": "",
         "enrollmentId": "0000001",
-        "examId": "ExampleCourse:M.1:WrittenExam:2021-02-16T10:00:00",
+        "examId": "ExampleCourse:M.1:WrittenExam:2022-02-12T10:00:00Z",
         "timestamp": "2020-12-31T23:59:59",
         "type": "Exam"
       }
@@ -654,7 +737,11 @@
         "invalidParams": [
           {
             "name": "admission.enrollmentId",
-            "reason": "The student is not matriculated in any examinationRegulation"
+            "reason": "The student is not admitted in the course of the exam."
+          },
+          {
+            "name": "admission.examId",
+            "reason": "The student is not admitted in the course of the exam."
           }
         ]
       }


### PR DESCRIPTION
### Reason for this PR
- missing semantic checks for examAdmissions

### Changes in this PR
- Check, if enrollmentId is matriculated in an examinationRegulation containing the moduleId, referenced in the exam behind the examId.
- Check, if enrollmentId is not admitted to the same exam already.
- Check, if enrollmentId is admitted to the couseId, referenced in the exam behind the examId.
- Check, if the examId is currently admittable

- update tests
