### PR TITLE
Refactor typeTokens

### DIFF
--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/ContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/ContractUtil.java
@@ -1,8 +1,6 @@
 package de.upb.cs.uc4.chaincode.contract;
 
-import de.upb.cs.uc4.chaincode.contract.examinationregulation.ExaminationRegulationContractUtil;
 import de.upb.cs.uc4.chaincode.contract.group.GroupContractUtil;
-import de.upb.cs.uc4.chaincode.contract.matriculationdata.MatriculationDataContractUtil;
 import de.upb.cs.uc4.chaincode.contract.operation.OperationContractUtil;
 import de.upb.cs.uc4.chaincode.exceptions.*;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.ledgeraccess.LedgerStateNotFoundError;
@@ -24,15 +22,9 @@ import org.hyperledger.fabric.shim.ledger.QueryResultsIterator;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
-import java.util.stream.Collectors;
-
-import static java.time.temporal.ChronoUnit.SECONDS;
 
 abstract public class ContractUtil {
 
@@ -42,10 +34,10 @@ abstract public class ContractUtil {
     protected String identifier = "";
 
     public DetailedError getUnprocessableEntityError(InvalidParameter invalidParam) {
-        return getUnprocessableEntityError(getArrayList(invalidParam));
+        return getUnprocessableEntityError(getList(invalidParam));
     }
 
-    public DetailedError getUnprocessableEntityError(ArrayList<InvalidParameter> invalidParams) {
+    public DetailedError getUnprocessableEntityError(List<InvalidParameter> invalidParams) {
         return new DetailedError()
                 .type("HLUnprocessableEntity")
                 .title("The following parameters do not conform to the specified format")
@@ -222,7 +214,7 @@ abstract public class ContractUtil {
         return stub.getStateByPartialCompositeKey(key);
     }
 
-    public ArrayList<InvalidParameter> getArrayList(InvalidParameter invalidParam) {
+    public List<InvalidParameter> getList(InvalidParameter invalidParam) {
         return new ArrayList<InvalidParameter>() {{
             add(invalidParam);
         }};
@@ -292,7 +284,7 @@ abstract public class ContractUtil {
     public <T> List<T> getAllStates(ChaincodeStub stub, Class<T> c) {
         QueryResultsIterator<KeyValue> qrIterator;
         qrIterator = getAllRawStates(stub);
-        ArrayList<T> resultItems = new ArrayList<>();
+        List<T> resultItems = new ArrayList<>();
         for (KeyValue item : qrIterator) {
             String jsonValue = item.getStringValue();
             try {
@@ -303,28 +295,5 @@ abstract public class ContractUtil {
             }
         }
         return resultItems;
-    }
-
-    public boolean checkModuleAvailable(ChaincodeStub stub, String enrollmentId, String moduleId) {
-        ExaminationRegulationContractUtil erUtil = new ExaminationRegulationContractUtil();
-        MatriculationDataContractUtil matUtil = new MatriculationDataContractUtil();
-
-        try {
-            MatriculationData matriculationData = matUtil.getState(stub, enrollmentId, MatriculationData.class);
-            List<SubjectMatriculation> matriculations = matriculationData.getMatriculationStatus();
-            for (SubjectMatriculation matriculation : matriculations) {
-                String examinationRegulationIdentifier = matriculation.getFieldOfStudy();
-                ExaminationRegulation examinationRegulation = erUtil.getState(stub, examinationRegulationIdentifier, ExaminationRegulation.class);
-                List<ExaminationRegulationModule> modules = examinationRegulation.getModules();
-                for (ExaminationRegulationModule module : modules) {
-                    if (module.getId().equals(moduleId)) {
-                        return true;
-                    }
-                }
-            }
-        } catch (LedgerAccessError e) {
-            return false;
-        }
-        return false;
     }
 }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContract.java
@@ -1,6 +1,5 @@
 package de.upb.cs.uc4.chaincode.contract.admission;
 
-import com.google.gson.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.ContractBase;
 import de.upb.cs.uc4.chaincode.exceptions.SerializableError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.LedgerAccessError;
@@ -15,9 +14,7 @@ import org.hyperledger.fabric.contract.annotation.Contract;
 import org.hyperledger.fabric.contract.annotation.Transaction;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 
-import java.lang.reflect.Type;
-import java.time.Instant;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Contract(
@@ -159,9 +156,8 @@ public class AdmissionContract extends ContractBase {
         } catch (SerializableError e) {
             return e.getJsonError();
         }
-        Type listType = new TypeToken<ArrayList<String>>() {}.getType();
-        List<String> admissionIdList = GsonWrapper.fromJson(admissionIds, listType);
-        List<String> examIdList = GsonWrapper.fromJson(examIds, listType);
+        List<String> admissionIdList = Arrays.asList(GsonWrapper.fromJson(admissionIds, String[].class).clone());
+        List<String> examIdList = Arrays.asList(GsonWrapper.fromJson(examIds, String[].class).clone());
         List<ExamAdmission> admissions = cUtil.getExamAdmissions(stub, admissionIdList, enrollmentId, examIdList);
         try {
             cUtil.finishOperation(stub, contractName,  transactionName, args);

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/admission/AdmissionContractUtil.java
@@ -1,6 +1,5 @@
 package de.upb.cs.uc4.chaincode.contract.admission;
 
-import com.google.gson.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.exam.ExamContractUtil;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.LedgerAccessError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.ParameterError;
@@ -17,7 +16,6 @@ import de.upb.cs.uc4.chaincode.model.exam.Exam;
 import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 
-import java.lang.reflect.Type;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -224,7 +222,7 @@ public class AdmissionContractUtil extends ContractUtil {
             throw new ParameterError(GsonWrapper.toJson(getConflictError()));
         }
 
-        ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
+        List<InvalidParameter> invalidParams = new ArrayList<>();
         invalidParams.addAll(newAdmission.getParameterErrors());
         invalidParams.addAll(newAdmission.getSemanticErrors(stub));
         if (!invalidParams.isEmpty()) {
@@ -247,15 +245,14 @@ public class AdmissionContractUtil extends ContractUtil {
         if (params.length != 3) {
             throw new ParameterError(GsonWrapper.toJson(getParamNumberError()));
         }
-        Type listType = new TypeToken<String[]>() {}.getType();
-        ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
+        List<InvalidParameter> invalidParams = new ArrayList<>();
         try {
-            GsonWrapper.fromJson(params[0], listType);
+            GsonWrapper.fromJson(params[0], String[].class);
         } catch (Exception e) {
             invalidParams.add(getUnparsableParam("admissionIds"));
         }
         try {
-            GsonWrapper.fromJson(params[2], listType);
+            GsonWrapper.fromJson(params[2], String[].class);
         } catch (Exception e) {
             invalidParams.add(getUnparsableParam("examIds"));
         }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/certificate/CertificateContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/certificate/CertificateContractUtil.java
@@ -18,16 +18,16 @@ public class CertificateContractUtil extends ContractUtil {
         identifier = "enrollmentId";
     }
 
-    private ArrayList<InvalidParameter> getErrorForEnrollmentId(final String enrollmentId) {
-        ArrayList<InvalidParameter> list = new ArrayList<>();
+    private List<InvalidParameter> getErrorForEnrollmentId(final String enrollmentId) {
+        List<InvalidParameter> list = new ArrayList<>();
         if (enrollmentId == null || enrollmentId.equals("")) {
             list.add(getEmptyEnrollmentIdParam());
         }
         return list;
     }
 
-    private ArrayList<InvalidParameter> getErrorForCertificate(final String certificate) {
-        ArrayList<InvalidParameter> list = new ArrayList<>();
+    private List<InvalidParameter> getErrorForCertificate(final String certificate) {
+        List<InvalidParameter> list = new ArrayList<>();
         if (certificate == null || certificate.equals("")) {
             list.add(getEmptyInvalidParameter("certificate"));
         }
@@ -43,7 +43,7 @@ public class CertificateContractUtil extends ContractUtil {
 
         ChaincodeStub stub = ctx.getStub();
 
-        ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
+        List<InvalidParameter> invalidParams = new ArrayList<>();
         invalidParams.addAll(getErrorForEnrollmentId(enrollmentId));
         invalidParams.addAll(getErrorForCertificate(certificate));
 
@@ -66,7 +66,7 @@ public class CertificateContractUtil extends ContractUtil {
 
         ChaincodeStub stub = ctx.getStub();
 
-        ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
+        List<InvalidParameter> invalidParams = new ArrayList<>();
         invalidParams.addAll(getErrorForEnrollmentId(enrollmentId));
         invalidParams.addAll(getErrorForCertificate(certificate));
 
@@ -89,7 +89,7 @@ public class CertificateContractUtil extends ContractUtil {
 
         ChaincodeStub stub = ctx.getStub();
 
-        ArrayList<InvalidParameter> invalidParams = new ArrayList<>(getErrorForEnrollmentId(enrollmentId));
+        List<InvalidParameter> invalidParams = new ArrayList<>(getErrorForEnrollmentId(enrollmentId));
         if (!invalidParams.isEmpty()) {
             throw new ParameterError(GsonWrapper.toJson(getUnprocessableEntityError(invalidParams)));
         }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/exam/ExamContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/exam/ExamContract.java
@@ -1,6 +1,5 @@
 package de.upb.cs.uc4.chaincode.contract.exam;
 
-import com.google.common.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.ContractBase;
 import de.upb.cs.uc4.chaincode.exceptions.SerializableError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.ParameterError;
@@ -15,6 +14,7 @@ import org.hyperledger.fabric.shim.ChaincodeStub;
 import java.lang.reflect.Type;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Contract(
@@ -97,14 +97,13 @@ public class ExamContract extends ContractBase {
             return e.getJsonError();
         }
 
-        Type listType = new TypeToken<ArrayList<String>>() {}.getType();
         List<Exam> examList = cUtil.getExams(
                 ctx.getStub(),
-                GsonWrapper.fromJson(examIds, listType),
-                GsonWrapper.fromJson(courseIds, listType),
-                GsonWrapper.fromJson(lecturerIds, listType),
-                GsonWrapper.fromJson(moduleIds, listType),
-                GsonWrapper.fromJson(types, listType),
+                Arrays.asList(GsonWrapper.fromJson(examIds, String[].class).clone()),
+                Arrays.asList(GsonWrapper.fromJson(courseIds, String[].class).clone()),
+                Arrays.asList(GsonWrapper.fromJson(lecturerIds, String[].class).clone()),
+                Arrays.asList(GsonWrapper.fromJson(moduleIds, String[].class).clone()),
+                Arrays.asList(GsonWrapper.fromJson(types, String[].class).clone()),
                 GsonWrapper.fromJson(admittableAt, Instant.class),
                 GsonWrapper.fromJson(droppableAt, Instant.class));
         return GsonWrapper.toJson(examList);

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/exam/ExamContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/exam/ExamContractUtil.java
@@ -1,6 +1,5 @@
 package de.upb.cs.uc4.chaincode.contract.exam;
 
-import com.google.common.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.ContractUtil;
 import de.upb.cs.uc4.chaincode.contract.certificate.CertificateContractUtil;
 import de.upb.cs.uc4.chaincode.contract.examinationregulation.ExaminationRegulationContractUtil;
@@ -72,13 +71,13 @@ public class ExamContractUtil extends ContractUtil {
      * @param exam exam to return errors for
      * @return a list of all errors found for the given exam
      */
-    public ArrayList<InvalidParameter> getSemanticErrorsForExam(
+    public List<InvalidParameter> getSemanticErrorsForExam(
             ChaincodeStub stub,
             Exam exam) {
 
         CertificateContractUtil certificateUtil = new CertificateContractUtil();
 
-        ArrayList<InvalidParameter> invalidParameters = new ArrayList<>();
+        List<InvalidParameter> invalidParameters = new ArrayList<>();
 
         // lecturer exists
         if (!(certificateUtil.keyExists(stub, exam.getLecturerEnrollmentId()))) {
@@ -125,10 +124,10 @@ public class ExamContractUtil extends ContractUtil {
      * @return a list of all errors found for the given exam
      */
 
-    public ArrayList<InvalidParameter> getParameterErrorsForExam(
+    public List<InvalidParameter> getParameterErrorsForExam(
             Exam exam) {
 
-        ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
+        List<InvalidParameter> invalidParams = new ArrayList<>();
 
         if (valueUnset(exam.getExamId())) {
             invalidParams.add(getEmptyEnrollmentIdParam(errorPrefix + ".examId"));
@@ -207,7 +206,7 @@ public class ExamContractUtil extends ContractUtil {
             throw new ParameterError(GsonWrapper.toJson(getConflictError()));
         }
 
-        ArrayList<InvalidParameter> invalidParams = getParameterErrorsForExam(exam);
+        List<InvalidParameter> invalidParams = getParameterErrorsForExam(exam);
         invalidParams.addAll(getSemanticErrorsForExam(stub, exam));
         if (!invalidParams.isEmpty()) {
             throw new ParameterError(GsonWrapper.toJson(getUnprocessableEntityError(invalidParams)));
@@ -226,32 +225,30 @@ public class ExamContractUtil extends ContractUtil {
         final String admittableAt = params[5];
         final String droppableAt = params[6];
 
-        ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
-        Type listType = new TypeToken<ArrayList<String>>() {
-        }.getType();
+        List<InvalidParameter> invalidParams = new ArrayList<>();
         try {
-            GsonWrapper.fromJson(examIds, listType);
+            GsonWrapper.fromJson(examIds, String[].class);
         } catch (Exception e) {
             invalidParams.add(getUnparsableParam("examIds"));
         }
         try {
-            GsonWrapper.fromJson(courseIds, listType);
+            GsonWrapper.fromJson(courseIds, String[].class);
         } catch (Exception e) {
             invalidParams.add(getUnparsableParam("courseIds"));
         }
         try {
-            GsonWrapper.fromJson(lecturerIds, listType);
+            GsonWrapper.fromJson(lecturerIds, String[].class);
         } catch (Exception e) {
             invalidParams.add(getUnparsableParam("lecturerIds"));
         }
         try {
-            GsonWrapper.fromJson(moduleIds, listType);
+            GsonWrapper.fromJson(moduleIds, String[].class);
         } catch (Exception e) {
             invalidParams.add(getUnparsableParam("moduleIds"));
         }
 
         try {
-            GsonWrapper.fromJson(types, listType);
+            GsonWrapper.fromJson(types, String[].class);
         } catch (Exception e) {
             invalidParams.add(getUnparsableParam("types"));
         }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/exam/ExamContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/exam/ExamContractUtil.java
@@ -242,10 +242,8 @@ public class ExamContractUtil extends ContractUtil {
             invalidParams.add(getUnparsableParam("moduleIds"));
         }
 
-        Type listTypeExamTypes = new TypeToken<ArrayList<ExamType>>() {
-        }.getType();
         try {
-            List<ExamType> examTypes = GsonWrapper.fromJson(types, ExamType[].class);
+            List<ExamType> examTypes = Arrays.asList(GsonWrapper.fromJson(types, ExamType[].class).clone());
             if (examTypes.stream().anyMatch(Objects::isNull)){
                 invalidParams.add(getInvalidEnumValue("types", ExamType.possibleStringValues()));
             }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/exam/ExamContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/exam/ExamContractUtil.java
@@ -12,7 +12,6 @@ import de.upb.cs.uc4.chaincode.model.exam.ExamType;
 import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 
-import java.lang.reflect.Type;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examinationregulation/ExaminationRegulationContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examinationregulation/ExaminationRegulationContract.java
@@ -1,6 +1,5 @@
 package de.upb.cs.uc4.chaincode.contract.examinationregulation;
 
-import com.google.gson.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.ContractBase;
 import de.upb.cs.uc4.chaincode.exceptions.SerializableError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.LedgerAccessError;
@@ -14,9 +13,8 @@ import org.hyperledger.fabric.contract.annotation.Contract;
 import org.hyperledger.fabric.contract.annotation.Transaction;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 
-import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 @Contract(
@@ -85,10 +83,9 @@ public class ExaminationRegulationContract extends ContractBase {
         } catch (SerializableError e) {
             return e.getJsonError();
         }
-        ArrayList<String> nameList;
-        Type listType = new TypeToken<ArrayList<String>>() {}.getType();
+        List<String> nameList;
         try {
-            nameList = GsonWrapper.fromJson(names, listType);
+            nameList = Arrays.asList(GsonWrapper.fromJson(names, String[].class).clone());
         } catch (Exception e) {
             return GsonWrapper.toJson(cUtil.getUnprocessableEntityError(cUtil.getUnparsableNameListParam()));
         }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examinationregulation/ExaminationRegulationContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examinationregulation/ExaminationRegulationContractUtil.java
@@ -1,6 +1,5 @@
 package de.upb.cs.uc4.chaincode.contract.examinationregulation;
 
-import com.google.gson.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.ContractUtil;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.LedgerAccessError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.ParameterError;
@@ -11,7 +10,6 @@ import de.upb.cs.uc4.chaincode.helper.GsonWrapper;
 import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -60,11 +58,11 @@ public class ExaminationRegulationContractUtil extends ContractUtil {
     }
 
     public boolean checkModuleAvailable(ChaincodeStub stub, String moduleId) {
-         return getValidModules(stub).stream().map(module -> module.getId()).anyMatch(item -> item.equals(moduleId));
+         return getValidModules(stub).stream().map(ExaminationRegulationModule::getId).anyMatch(item -> item.equals(moduleId));
     }
 
-    public ArrayList<InvalidParameter> getErrorForExaminationRegulation(ExaminationRegulation examinationRegulation, Set<ExaminationRegulationModule> validModules) {
-        ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
+    public List<InvalidParameter> getErrorForExaminationRegulation(ExaminationRegulation examinationRegulation, Set<ExaminationRegulationModule> validModules) {
+        List<InvalidParameter> invalidParams = new ArrayList<>();
 
         if (valueUnset(examinationRegulation.getName())) {
             invalidParams.add(getEmptyInvalidParameter(this.prefix + ".name"));
@@ -77,13 +75,13 @@ public class ExaminationRegulationContractUtil extends ContractUtil {
         return invalidParams;
     }
 
-    public ArrayList<InvalidParameter> getErrorForModuleList(List<ExaminationRegulationModule> modules, String errorName, Set<ExaminationRegulationModule> validModules) {
-        ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
+    public List<InvalidParameter> getErrorForModuleList(List<ExaminationRegulationModule> modules, String errorName, Set<ExaminationRegulationModule> validModules) {
+        List<InvalidParameter> invalidParams = new ArrayList<>();
 
         if (valueUnset(modules)) {
             invalidParams.add(getEmptyInvalidParameter(errorName));
         } else {
-            ArrayList<String> existingModules = new ArrayList<>();
+            List<String> existingModules = new ArrayList<>();
 
             for (int moduleIndex = 0; moduleIndex < modules.size(); moduleIndex++) {
 
@@ -127,7 +125,7 @@ public class ExaminationRegulationContractUtil extends ContractUtil {
         }
 
         HashSet<ExaminationRegulationModule> validModules = getValidModules(stub);
-        ArrayList<InvalidParameter> invalidParams = getErrorForExaminationRegulation(newExaminationRegulation, validModules);
+        List<InvalidParameter> invalidParams = getErrorForExaminationRegulation(newExaminationRegulation, validModules);
 
         if (!invalidParams.isEmpty()) {
             throw new ParameterError(GsonWrapper.toJson(getUnprocessableEntityError(invalidParams)));
@@ -145,9 +143,8 @@ public class ExaminationRegulationContractUtil extends ContractUtil {
         }
         String names = params[0];
 
-        Type listType = new TypeToken<ArrayList<String>>() {}.getType();
         try {
-            GsonWrapper.fromJson(names, listType);
+            GsonWrapper.fromJson(names, String[].class);
         } catch (Exception e) {
             throw new ParameterError(GsonWrapper.toJson(getUnprocessableEntityError(getUnparsableNameListParam())));
         }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examresult/ExamResultContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examresult/ExamResultContract.java
@@ -1,11 +1,9 @@
 package de.upb.cs.uc4.chaincode.contract.examresult;
 
-import com.google.common.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.ContractBase;
 import de.upb.cs.uc4.chaincode.exceptions.SerializableError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.LedgerAccessError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.ParameterError;
-import de.upb.cs.uc4.chaincode.exceptions.serializable.ValidationError;
 import de.upb.cs.uc4.chaincode.helper.GsonWrapper;
 import de.upb.cs.uc4.chaincode.helper.HyperledgerManager;
 import de.upb.cs.uc4.chaincode.model.examresult.ExamResultEntry;
@@ -15,10 +13,7 @@ import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.contract.annotation.Transaction;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 
-import java.lang.reflect.Type;
-import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 @Contract(
@@ -98,11 +93,8 @@ public class ExamResultContract extends ContractBase {
             return e.getJsonError();
         }
 
-        Type listType = new TypeToken<ArrayList<String>>() {}.getType();
-        List<ExamResultEntry>examResults = cUtil.getExamResultEntries(
-                stub,
-                enrollmentId,
-                GsonWrapper.fromJson(examIds, listType));
+        List<ExamResultEntry>examResults = cUtil.getExamResultEntries(stub, enrollmentId,
+                Arrays.asList(GsonWrapper.fromJson(examIds, String[].class).clone()));
         return GsonWrapper.toJson(examResults);
     }
 

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examresult/ExamResultContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/examresult/ExamResultContractUtil.java
@@ -1,6 +1,5 @@
 package de.upb.cs.uc4.chaincode.contract.examresult;
 
-import com.google.common.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.ContractUtil;
 import de.upb.cs.uc4.chaincode.contract.certificate.CertificateContractUtil;
 import de.upb.cs.uc4.chaincode.contract.exam.ExamContractUtil;
@@ -15,10 +14,7 @@ import de.upb.cs.uc4.chaincode.model.errors.InvalidParameter;
 import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 
-import java.lang.reflect.Type;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -126,7 +122,7 @@ public class ExamResultContractUtil extends ContractUtil {
         if(this.keyExists(ctx.getStub(), getKey(newExamResult))){
             throw new ParameterError(GsonWrapper.toJson(getConflictError("exam result", "exam")));
         }
-        ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
+        List<InvalidParameter> invalidParams = new ArrayList<>();
         List<ExamResultEntry> examResultEntries = newExamResult.getExamResultEntries();
         //for each entry
         for (int i=0; i< examResultEntries.size();i++){
@@ -153,7 +149,7 @@ public class ExamResultContractUtil extends ContractUtil {
     }
 
     private boolean distinctExamIds(List<ExamResultEntry> entries) {
-        return entries.stream().map(entry -> entry.getExamId()).distinct().count() > 1;
+        return entries.stream().map(ExamResultEntry::getExamId).distinct().count() > 1;
     }
 
     public void checkParamsGetExamResultEntries(Context ctx, String[] params) throws ParameterError {
@@ -162,10 +158,9 @@ public class ExamResultContractUtil extends ContractUtil {
         }
         String examIds = params[1];
 
-        ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
-        Type listType = new TypeToken<ArrayList<String>>() {}.getType();
+        List<InvalidParameter> invalidParams = new ArrayList<>();
         try {
-            GsonWrapper.fromJson(examIds, listType);
+            GsonWrapper.fromJson(examIds, String[].class);
         } catch (Exception e) {
             invalidParams.add(getUnparsableParam("examIds"));
         }
@@ -181,7 +176,7 @@ public class ExamResultContractUtil extends ContractUtil {
 
         return this.getAllStates(stub, ExamResult.class).stream()
                 .map(result -> result.getExamResultEntries().stream())
-                .reduce((entries1, entries2) -> Stream.concat(entries1, entries2))
+                .reduce(Stream::concat)
                 .orElse(Stream.empty())
                 .filter(item -> enrollmentId.isEmpty() ||
                         enrollmentId.equals(item.getEnrollmentId()))

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/group/GroupContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/group/GroupContractUtil.java
@@ -43,13 +43,13 @@ public class GroupContractUtil extends ContractUtil {
      * @param enrollmentId group to return errors for
      * @return a list of all errors found for the given matriculationData
      */
-    public ArrayList<InvalidParameter> getSemanticErrorsForUserInGroup(
+    public List<InvalidParameter> getSemanticErrorsForUserInGroup(
             ChaincodeStub stub,
             String enrollmentId) {
 
         CertificateContractUtil certificateUtil = new CertificateContractUtil();
 
-        ArrayList<InvalidParameter> invalidParameters = new ArrayList<>();
+        List<InvalidParameter> invalidParameters = new ArrayList<>();
 
         if (!(certificateUtil.keyExists(stub, enrollmentId))) {
             invalidParameters.add(getInvalidUserNotRegistered());
@@ -64,9 +64,9 @@ public class GroupContractUtil extends ContractUtil {
      * @param enrollmentId enrollmentId to return errors for
      * @return a list of all errors found for the given matriculationData
      */
-    public ArrayList<InvalidParameter> getParameterErrorsForEnrollmentId(String enrollmentId) {
+    public List<InvalidParameter> getParameterErrorsForEnrollmentId(String enrollmentId) {
 
-        ArrayList<InvalidParameter> invalidparams = new ArrayList<>();
+        List<InvalidParameter> invalidparams = new ArrayList<>();
 
         if (valueUnset(enrollmentId)) {
             invalidparams.add(getEmptyInvalidParameter(errorPrefix + ".enrollmentId"));
@@ -75,8 +75,8 @@ public class GroupContractUtil extends ContractUtil {
         return invalidparams;
     }
 
-    public ArrayList<InvalidParameter> getParameterErrorsForGroupId(String groupId) {
-        ArrayList<InvalidParameter> invalidparams = new ArrayList<>();
+    public List<InvalidParameter> getParameterErrorsForGroupId(String groupId) {
+        List<InvalidParameter> invalidparams = new ArrayList<>();
 
         if (valueUnset(groupId)) {
             invalidparams.add(getEmptyInvalidParameter(errorPrefix + ".groupId"));
@@ -110,7 +110,7 @@ public class GroupContractUtil extends ContractUtil {
 
         ChaincodeStub stub = ctx.getStub();
 
-        ArrayList<InvalidParameter> invalidParams = getParameterErrorsForEnrollmentId(enrollmentId);
+        List<InvalidParameter> invalidParams = getParameterErrorsForEnrollmentId(enrollmentId);
         invalidParams.addAll(getParameterErrorsForGroupId(groupId));
         invalidParams.addAll(getSemanticErrorsForUserInGroup(stub, enrollmentId));
         if (!invalidParams.isEmpty()) {
@@ -126,7 +126,7 @@ public class GroupContractUtil extends ContractUtil {
         String groupId = params[1];
 
         ChaincodeStub stub = ctx.getStub();
-        ArrayList<InvalidParameter> invalidParams = getParameterErrorsForEnrollmentId(enrollmentId);
+        List<InvalidParameter> invalidParams = getParameterErrorsForEnrollmentId(enrollmentId);
         invalidParams.addAll(getParameterErrorsForGroupId(groupId));
         if (!invalidParams.isEmpty()) {
             throw new ParameterError(GsonWrapper.toJson(getUnprocessableEntityError(invalidParams)));
@@ -143,7 +143,7 @@ public class GroupContractUtil extends ContractUtil {
         }
         String enrollmentId = params[0];
 
-        ArrayList<InvalidParameter> invalidParams = getParameterErrorsForEnrollmentId(enrollmentId);
+        List<InvalidParameter> invalidParams = getParameterErrorsForEnrollmentId(enrollmentId);
         if (!invalidParams.isEmpty()) {
             throw new ParameterError(GsonWrapper.toJson(getUnprocessableEntityError(invalidParams)));
         }
@@ -156,7 +156,7 @@ public class GroupContractUtil extends ContractUtil {
         String groupId = params[0];
 
         ChaincodeStub stub = ctx.getStub();
-        ArrayList<InvalidParameter> invalidParams = getParameterErrorsForGroupId(groupId);
+        List<InvalidParameter> invalidParams = getParameterErrorsForGroupId(groupId);
         if (!invalidParams.isEmpty()) {
             throw new ParameterError(GsonWrapper.toJson(getUnprocessableEntityError(invalidParams)));
         }
@@ -170,7 +170,7 @@ public class GroupContractUtil extends ContractUtil {
         }
         String enrollmentId = params[0];
 
-        ArrayList<InvalidParameter> invalidParams = getParameterErrorsForEnrollmentId(enrollmentId);
+        List<InvalidParameter> invalidParams = getParameterErrorsForEnrollmentId(enrollmentId);
         if (!invalidParams.isEmpty()) {
             throw new ParameterError(GsonWrapper.toJson(getUnprocessableEntityError(invalidParams)));
         }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/matriculationdata/MatriculationDataContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/matriculationdata/MatriculationDataContract.java
@@ -1,6 +1,5 @@
 package de.upb.cs.uc4.chaincode.contract.matriculationdata;
 
-import com.google.gson.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.ContractBase;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.LedgerAccessError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.ParameterError;
@@ -14,9 +13,8 @@ import org.hyperledger.fabric.contract.annotation.Contract;
 import org.hyperledger.fabric.contract.annotation.Transaction;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.List;
 
 @Contract(
         name = MatriculationDataContract.contractName
@@ -159,9 +157,8 @@ public class MatriculationDataContract extends ContractBase {
         } catch (SerializableError e) {
             return e.getJsonError();
         }
-        Type listType = new TypeToken<ArrayList<SubjectMatriculation>>() {}.getType();
-        ArrayList<SubjectMatriculation> matriculationStatus;
-        matriculationStatus = GsonWrapper.fromJson(matriculations, listType);
+        List<SubjectMatriculation> matriculationStatus;
+        matriculationStatus = Arrays.asList(GsonWrapper.fromJson(matriculations, SubjectMatriculation[].class));
 
         MatriculationData matriculationData;
         try {

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/matriculationdata/MatriculationDataContractUtil.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/matriculationdata/MatriculationDataContractUtil.java
@@ -1,6 +1,5 @@
 package de.upb.cs.uc4.chaincode.contract.matriculationdata;
 
-import com.google.gson.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.ContractUtil;
 import de.upb.cs.uc4.chaincode.contract.examinationregulation.ExaminationRegulationContractUtil;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.LedgerAccessError;
@@ -14,8 +13,8 @@ import de.upb.cs.uc4.chaincode.helper.GsonWrapper;
 import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 
-import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -68,7 +67,7 @@ public class MatriculationDataContractUtil extends ContractUtil {
      * @param prefix            prefix used for error information
      * @return a list of all errors found for the given matriculationData
      */
-    public ArrayList<InvalidParameter> getErrorForMatriculationData(
+    public List<InvalidParameter> getErrorForMatriculationData(
             ChaincodeStub stub,
             MatriculationData matriculationData,
             String prefix) {
@@ -76,7 +75,7 @@ public class MatriculationDataContractUtil extends ContractUtil {
         if (!prefix.isEmpty())
             prefix += ".";
 
-        ArrayList<InvalidParameter> invalidparams = new ArrayList<>();
+        List<InvalidParameter> invalidparams = new ArrayList<>();
 
         if (valueUnset(matriculationData.getEnrollmentId())) {
             invalidparams.add(getEmptyEnrollmentIdParam(prefix));
@@ -89,18 +88,18 @@ public class MatriculationDataContractUtil extends ContractUtil {
         return invalidparams;
     }
 
-    public ArrayList<InvalidParameter> getErrorForSubjectMatriculationList(
+    public List<InvalidParameter> getErrorForSubjectMatriculationList(
             ChaincodeStub stub,
             List<SubjectMatriculation> matriculationStatus,
             String prefix) {
         ExaminationRegulationContractUtil eUtil = new ExaminationRegulationContractUtil();
 
-        ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
+        List<InvalidParameter> invalidParams = new ArrayList<>();
 
         if (valueUnset(matriculationStatus)) {
             invalidParams.add(getEmptyInvalidParameter(prefix));
         } else {
-            ArrayList<String> existingFields = new ArrayList<>();
+            List<String> existingFields = new ArrayList<>();
 
             List<String> validErIds = eUtil.getAllStates(stub, ExaminationRegulation.class).stream().map(ExaminationRegulation::getName).collect(Collectors.toList());
             for (int subMatIndex = 0; subMatIndex < matriculationStatus.size(); subMatIndex++) {
@@ -124,7 +123,7 @@ public class MatriculationDataContractUtil extends ContractUtil {
                     invalidParams.add(getEmptyInvalidParameter(prefix + "[" + subMatIndex + "].semesters"));
                 }
 
-                ArrayList<String> existingSemesters = new ArrayList<>();
+                List<String> existingSemesters = new ArrayList<>();
                 for (int semesterIndex = 0; semesterIndex < Objects.requireNonNull(semesters).size(); semesterIndex++) {
 
                     String semester = semesters.get(semesterIndex);
@@ -179,7 +178,7 @@ public class MatriculationDataContractUtil extends ContractUtil {
             throw new ParameterError(GsonWrapper.toJson(getUnprocessableEntityError(getUnparsableMatriculationDataParam())));
         }
 
-        ArrayList<InvalidParameter> invalidParams = getErrorForMatriculationData(stub, newMatriculationData, "matriculationData");
+        List<InvalidParameter> invalidParams = getErrorForMatriculationData(stub, newMatriculationData, "matriculationData");
         if (!invalidParams.isEmpty()) {
             throw new ParameterError(GsonWrapper.toJson(getUnprocessableEntityError(invalidParams)));
         }
@@ -204,7 +203,7 @@ public class MatriculationDataContractUtil extends ContractUtil {
             throw new ParameterError(GsonWrapper.toJson(getUnprocessableEntityError(getUnparsableMatriculationDataParam())));
         }
 
-        ArrayList<InvalidParameter> invalidParams = getErrorForMatriculationData(stub, newMatriculationData, "matriculationData");
+        List<InvalidParameter> invalidParams = getErrorForMatriculationData(stub, newMatriculationData, "matriculationData");
         if (!invalidParams.isEmpty()) {
             throw new ParameterError(GsonWrapper.toJson(getUnprocessableEntityError(invalidParams)));
         }
@@ -237,14 +236,13 @@ public class MatriculationDataContractUtil extends ContractUtil {
 
         ChaincodeStub stub = ctx.getStub();
 
-        ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
+        List<InvalidParameter> invalidParams = new ArrayList<>();
         if (valueUnset(enrollmentId)) {
             invalidParams.add(getEmptyEnrollmentIdParam());
         }
-        Type listType = new TypeToken<ArrayList<SubjectMatriculation>>() {}.getType();
-        ArrayList<SubjectMatriculation> matriculationStatus;
+        List<SubjectMatriculation> matriculationStatus;
         try {
-            matriculationStatus = GsonWrapper.fromJson(matriculations, listType);
+            matriculationStatus = Arrays.asList(GsonWrapper.fromJson(matriculations, SubjectMatriculation[].class));
         } catch (Exception e) {
             invalidParams.add(getUnparsableMatriculationParam());
             throw new ParameterError(GsonWrapper.toJson(getUnprocessableEntityError(invalidParams)));

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/operation/OperationContract.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/contract/operation/OperationContract.java
@@ -1,6 +1,5 @@
 package de.upb.cs.uc4.chaincode.contract.operation;
 
-import com.google.common.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.ContractBase;
 import de.upb.cs.uc4.chaincode.exceptions.SerializableError;
 import de.upb.cs.uc4.chaincode.exceptions.serializable.LedgerAccessError;
@@ -13,9 +12,9 @@ import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.contract.annotation.Contract;
 import org.hyperledger.fabric.contract.annotation.Transaction;
 
-import java.lang.reflect.Type;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Contract(
@@ -154,18 +153,17 @@ public class OperationContract extends ContractBase {
             final String initiatorEnrollmentId,
             final String involvedEnrollmentId,
             final String states) {
-        Type listType = new TypeToken<ArrayList<String>>() {}.getType();
 
-        ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
+        List<InvalidParameter> invalidParams = new ArrayList<>();
         List<String> operationIdList = null;
         try {
-            operationIdList = GsonWrapper.fromJson(operationIds, listType);
+            operationIdList = Arrays.asList(GsonWrapper.fromJson(operationIds, String[].class).clone());
         } catch (Exception e) {
             invalidParams.add(cUtil.getUnparsableParam("operationIds"));
         }
         List<String> stateList = null;
         try {
-            stateList = GsonWrapper.fromJson(states, listType);
+            stateList = Arrays.asList(GsonWrapper.fromJson(states, String[].class).clone());
         } catch (Exception e) {
             invalidParams.add(cUtil.getUnparsableParam("states"));
         }
@@ -181,6 +179,6 @@ public class OperationContract extends ContractBase {
                         initiatorEnrollmentId,
                         involvedEnrollmentId,
                         stateList);
-        return GsonWrapper.toJson(operations);
+        return GsonWrapper.toJson(operations.toArray());
     }
 }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/AccessManager.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/AccessManager.java
@@ -1,6 +1,5 @@
 package de.upb.cs.uc4.chaincode.helper;
 
-import com.google.gson.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContract;
 import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContractUtil;
 import de.upb.cs.uc4.chaincode.contract.certificate.CertificateContract;
@@ -21,12 +20,11 @@ import de.upb.cs.uc4.chaincode.model.examresult.ExamResult;
 import de.upb.cs.uc4.chaincode.model.examresult.ExamResultEntry;
 import org.hyperledger.fabric.contract.Context;
 
-import java.lang.reflect.Type;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class AccessManager {
-    private static OperationContractUtil operationUtil = new OperationContractUtil();
+    private static final OperationContractUtil operationUtil = new OperationContractUtil();
 
     public static final String ADMIN = "Admin";
     public static final String SYSTEM = "System";
@@ -34,9 +32,7 @@ public class AccessManager {
     public static final String HLF_ATTRIBUTE_SYSADMIN = "sysAdmin";
 
     public static ApprovalList getRequiredApprovals(Context ctx, String contractName, String transactionName, String params) throws MissingTransactionError, LedgerAccessError {
-        Type listType = new TypeToken<ArrayList<String>>() {
-        }.getType();
-        List<String> paramList = GsonWrapper.fromJson(params, listType);
+        List<String> paramList = Arrays.asList(GsonWrapper.fromJson(params, String[].class).clone());
         switch (contractName) {
             case MatriculationDataContract.contractName:
                 switch (transactionName) {

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/GsonWrapper.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/GsonWrapper.java
@@ -1,6 +1,5 @@
 package de.upb.cs.uc4.chaincode.helper;
 
-import com.google.common.reflect.TypeToken;
 import com.google.gson.*;
 import de.upb.cs.uc4.chaincode.model.Dummy;
 import de.upb.cs.uc4.chaincode.model.admission.AbstractAdmission;
@@ -8,12 +7,9 @@ import de.upb.cs.uc4.chaincode.model.admission.AdmissionType;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Whitelist;
 
-import java.io.Reader;
-import java.lang.reflect.Type;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 
 public class GsonWrapper {
 
@@ -78,6 +74,11 @@ public class GsonWrapper {
             .create();
 
     public static <T> T fromJson(String json, Class<T> t) throws JsonSyntaxException {
+        if (t.equals(String[].class)) {
+            if (json == null || json.equals("")) {
+                return cleanGson.fromJson("[]", t);
+            }
+        }
         if (t.equals(Instant.class)) {
             return (T) InstantAdapter.internalDeserialize(json);
         }
@@ -89,22 +90,5 @@ public class GsonWrapper {
             return InstantAdapter.internalSerialize((Instant) object);
         }
         return gson.toJson(object);
-    }
-
-    public static <T> T fromJson(Reader reader, Type type) {
-        return gson.fromJson(reader, type);
-    }
-
-    public static <T> T fromJson(String json, Type type) {
-        Type listType = new TypeToken<ArrayList<String>> () {}.getType();
-        if (type.equals(listType)) {
-            if (json == null || json.equals("")) {
-                return cleanGson.fromJson("[]", type);
-            }
-        }
-        if (type.equals(Instant.class)) {
-            return (T) InstantAdapter.internalDeserialize(json);
-        }
-        return gson.fromJson(json, type);
     }
 }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/ValidationManager.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/helper/ValidationManager.java
@@ -1,6 +1,5 @@
 package de.upb.cs.uc4.chaincode.helper;
 
-import com.google.gson.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContract;
 import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContractUtil;
 import de.upb.cs.uc4.chaincode.contract.certificate.CertificateContract;
@@ -20,21 +19,18 @@ import de.upb.cs.uc4.chaincode.exceptions.serializable.parameter.MissingTransact
 import de.upb.cs.uc4.chaincode.exceptions.SerializableError;
 import org.hyperledger.fabric.contract.Context;
 
-import java.lang.reflect.Type;
-
 public class ValidationManager {
-    private static AdmissionContractUtil admissionUtil = new AdmissionContractUtil();
-    private static OperationContractUtil operationUtil = new OperationContractUtil();
-    private static CertificateContractUtil certificateUtil = new CertificateContractUtil();
-    private static ExaminationRegulationContractUtil examinationRegulationUtil = new ExaminationRegulationContractUtil();
-    private static GroupContractUtil groupUtil = new GroupContractUtil();
-    private static MatriculationDataContractUtil matriculationDataUtil = new MatriculationDataContractUtil();
-    private static ExamContractUtil examUtil = new ExamContractUtil();
-    private static ExamResultContractUtil examResultContractUtil = new ExamResultContractUtil();
+    private static final AdmissionContractUtil admissionUtil = new AdmissionContractUtil();
+    private static final OperationContractUtil operationUtil = new OperationContractUtil();
+    private static final CertificateContractUtil certificateUtil = new CertificateContractUtil();
+    private static final ExaminationRegulationContractUtil examinationRegulationUtil = new ExaminationRegulationContractUtil();
+    private static final GroupContractUtil groupUtil = new GroupContractUtil();
+    private static final MatriculationDataContractUtil matriculationDataUtil = new MatriculationDataContractUtil();
+    private static final ExamContractUtil examUtil = new ExamContractUtil();
+    private static final ExamResultContractUtil examResultContractUtil = new ExamResultContractUtil();
 
     public static void validateParams(Context ctx, String contractName, String transactionName, String params) throws SerializableError {
-        Type listType = new TypeToken<String[]>() {}.getType();
-        String[] paramList = GsonWrapper.fromJson(params, listType);
+        String[] paramList = GsonWrapper.fromJson(params, String[].class);
         switch (contractName) {
             case MatriculationDataContract.contractName:
                 switch (transactionName) {

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/MatriculationData.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/MatriculationData.java
@@ -101,7 +101,7 @@ public class MatriculationData {
         return o.toString().replace("\n", "\n    ");
     }
 
-    public void addAbsent(ArrayList<SubjectMatriculation> matriculationStatus) {
+    public void addAbsent(List<SubjectMatriculation> matriculationStatus) {
         for (SubjectMatriculation newItem : matriculationStatus) {
             boolean exists = false;
             for (SubjectMatriculation item : this.getMatriculationStatus()) {

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/AbstractAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/AbstractAdmission.java
@@ -8,6 +8,7 @@ import org.hyperledger.fabric.shim.ChaincodeStub;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 public abstract class AbstractAdmission {
@@ -105,9 +106,9 @@ public abstract class AbstractAdmission {
         return o.toString().replace("\n", "\n    ");
     }
 
-    public ArrayList<InvalidParameter> getParameterErrors() {
+    public List<InvalidParameter> getParameterErrors() {
         AdmissionContractUtil cUtil = new AdmissionContractUtil();
-        ArrayList<InvalidParameter> invalidParams = new ArrayList<>();
+        List<InvalidParameter> invalidParams = new ArrayList<>();
 
         if (cUtil.valueUnset(this.enrollmentId)) {
             invalidParams.add(cUtil.getEmptyEnrollmentIdParam(cUtil.getErrorPrefix() + "."));
@@ -119,9 +120,9 @@ public abstract class AbstractAdmission {
         return invalidParams;
     }
 
-    public ArrayList<InvalidParameter> getSemanticErrors(ChaincodeStub stub) {
+    public List<InvalidParameter> getSemanticErrors(ChaincodeStub stub) {
         AdmissionContractUtil cUtil = new AdmissionContractUtil();
-        ArrayList<InvalidParameter> invalidParameters = new ArrayList<>();
+        List<InvalidParameter> invalidParameters = new ArrayList<>();
         if (!cUtil.checkStudentMatriculated(stub, this)) {
             invalidParameters.add(cUtil.getStudentNotMatriculatedParam("enrollmentId"));
         }

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/CourseAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/CourseAdmission.java
@@ -7,6 +7,7 @@ import io.swagger.annotations.ApiModelProperty;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 public class CourseAdmission extends AbstractAdmission {
@@ -96,9 +97,9 @@ public class CourseAdmission extends AbstractAdmission {
     }
 
     @Override
-    public ArrayList<InvalidParameter> getParameterErrors() {
+    public List<InvalidParameter> getParameterErrors() {
         AdmissionContractUtil cUtil = new AdmissionContractUtil();
-        ArrayList<InvalidParameter> invalidParams = super.getParameterErrors();
+        List<InvalidParameter> invalidParams = super.getParameterErrors();
 
         if (cUtil.valueUnset(this.getCourseId())) {
             invalidParams.add(cUtil.getEmptyInvalidParameter(cUtil.getErrorPrefix() + ".courseId"));
@@ -111,9 +112,9 @@ public class CourseAdmission extends AbstractAdmission {
     }
 
     @Override
-    public ArrayList<InvalidParameter> getSemanticErrors(ChaincodeStub stub) {
+    public List<InvalidParameter> getSemanticErrors(ChaincodeStub stub) {
         AdmissionContractUtil cUtil = new AdmissionContractUtil();
-        ArrayList<InvalidParameter> invalidParameters = super.getSemanticErrors(stub);
+        List<InvalidParameter> invalidParameters = super.getSemanticErrors(stub);
 
         if (!cUtil.checkModuleAvailable(stub, this)) {
             invalidParameters.add(cUtil.getInvalidModuleAvailable("moduleId"));

--- a/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/ExamAdmission.java
+++ b/UC4-chaincode/src/main/java/de/upb/cs/uc4/chaincode/model/admission/ExamAdmission.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiModelProperty;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 public class ExamAdmission extends AbstractAdmission {
@@ -78,9 +79,9 @@ public class ExamAdmission extends AbstractAdmission {
 
 
     @Override
-    public ArrayList<InvalidParameter> getParameterErrors() {
+    public List<InvalidParameter> getParameterErrors() {
         AdmissionContractUtil cUtil = new AdmissionContractUtil();
-        ArrayList<InvalidParameter> invalidParams = super.getParameterErrors();
+        List<InvalidParameter> invalidParams = super.getParameterErrors();
 
         if (cUtil.valueUnset(this.examId)) {
             invalidParams.add(cUtil.getEmptyInvalidParameter(cUtil.getErrorPrefix() + ".examId"));
@@ -89,9 +90,9 @@ public class ExamAdmission extends AbstractAdmission {
         return invalidParams;
     }
 
-    public ArrayList<InvalidParameter> getSemanticErrors(ChaincodeStub stub) {
+    public List<InvalidParameter> getSemanticErrors(ChaincodeStub stub) {
         AdmissionContractUtil cUtil = new AdmissionContractUtil();
-        ArrayList<InvalidParameter> invalidParameters = super.getSemanticErrors(stub);
+        List<InvalidParameter> invalidParameters = super.getSemanticErrors(stub);
 
         if (!cUtil.checkExamExists(stub, this)) {
             invalidParameters.add(cUtil.getAdmissionExamNotExistsParam());

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/CertificateContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/CertificateContractTest.java
@@ -1,26 +1,14 @@
 package de.upb.cs.uc4.chaincode;
 
-
-import com.google.gson.reflect.TypeToken;
-import de.upb.cs.uc4.chaincode.contract.admission.AdmissionContract;
 import de.upb.cs.uc4.chaincode.contract.certificate.CertificateContract;
-import de.upb.cs.uc4.chaincode.contract.operation.OperationContract;
-import de.upb.cs.uc4.chaincode.mock.MockChaincodeStub;
 import de.upb.cs.uc4.chaincode.model.JsonIOTest;
 import de.upb.cs.uc4.chaincode.model.JsonIOTestSetup;
 import de.upb.cs.uc4.chaincode.contract.certificate.CertificateContractUtil;
-import de.upb.cs.uc4.chaincode.helper.GsonWrapper;
 import de.upb.cs.uc4.chaincode.util.TestUtil;
 import org.hyperledger.fabric.contract.Context;
 import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.function.Executable;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/ExamContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/ExamContractTest.java
@@ -1,6 +1,5 @@
 package de.upb.cs.uc4.chaincode;
 
-import com.google.common.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.exam.ExamContract;
 import de.upb.cs.uc4.chaincode.contract.exam.ExamContractUtil;
 import de.upb.cs.uc4.chaincode.helper.GsonWrapper;
@@ -14,8 +13,7 @@ import org.hyperledger.fabric.contract.Context;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.function.Executable;
 
-import java.lang.reflect.Type;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -97,9 +95,8 @@ public final class ExamContractTest extends TestCreationBase {
             String getResult = contract.getExams(ctx, input.get(0), input.get(1), input.get(2), input.get(3), input.get(4), input.get(5), input.get(6));
             assertThat(getResult).isEqualTo(compare.get(0));
 
-            Type listType = new TypeToken<ArrayList<OperationData>>() {}.getType();
-            List<OperationData> getExamsList = GsonWrapper.fromJson(getResult, listType);
-            List<OperationData> compareList = GsonWrapper.fromJson(compare.get(0), listType);
+            List<OperationData> getExamsList = Arrays.asList(GsonWrapper.fromJson(getResult, OperationData[].class).clone());
+            List<OperationData> compareList = Arrays.asList(GsonWrapper.fromJson(compare.get(0), OperationData[].class).clone());
             assertThat(getExamsList).isEqualTo(compareList);
         };
     }

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/ExamResultContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/ExamResultContractTest.java
@@ -1,15 +1,12 @@
 package de.upb.cs.uc4.chaincode;
 
 
-import com.google.common.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.examresult.ExamResultContract;
 import de.upb.cs.uc4.chaincode.contract.examresult.ExamResultContractUtil;
-import de.upb.cs.uc4.chaincode.contract.matriculationdata.MatriculationDataContract;
 import de.upb.cs.uc4.chaincode.contract.operation.OperationContract;
 import de.upb.cs.uc4.chaincode.helper.GsonWrapper;
 import de.upb.cs.uc4.chaincode.model.JsonIOTest;
 import de.upb.cs.uc4.chaincode.model.JsonIOTestSetup;
-import de.upb.cs.uc4.chaincode.model.MatriculationData;
 import de.upb.cs.uc4.chaincode.model.examresult.ExamResult;
 import de.upb.cs.uc4.chaincode.model.examresult.ExamResultEntry;
 import de.upb.cs.uc4.chaincode.util.TestUtil;
@@ -18,8 +15,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
-import java.lang.reflect.Type;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,10 +68,9 @@ public final class ExamResultContractTest extends TestCreationBase {
         return () -> {
             Context ctx = TestUtil.buildContext(ExamResultContract.contractName, ExamResultContract.transactionNameGetExamResultEntries, setup, input, ids);
 
-            Type listType = new TypeToken<ArrayList<ExamResultEntry>>() {}.getType();
-            List<ExamResultEntry> compareExamResult = GsonWrapper.fromJson(compare.get(0), listType);
-            List<ExamResultEntry> ledgerExamResult = GsonWrapper.fromJson(
-                    contract.getExamResultEntries(ctx, input.get(0), input.get(1)), listType);
+            List<ExamResultEntry> compareExamResult = Arrays.asList(GsonWrapper.fromJson(compare.get(0), ExamResultEntry[].class).clone());
+            List<ExamResultEntry> ledgerExamResult = Arrays.asList(GsonWrapper.fromJson(
+                    contract.getExamResultEntries(ctx, input.get(0), input.get(1)), ExamResultEntry[].class).clone());
             assertThat(ledgerExamResult).isEqualTo(compareExamResult);
         };
     }

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/OperationContractTest.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/OperationContractTest.java
@@ -1,7 +1,6 @@
 package de.upb.cs.uc4.chaincode;
 
 
-import com.google.common.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.contract.matriculationdata.MatriculationDataContract;
 import de.upb.cs.uc4.chaincode.contract.operation.OperationContract;
 import de.upb.cs.uc4.chaincode.mock.MockChaincodeStub;
@@ -13,9 +12,8 @@ import org.hyperledger.fabric.contract.Context;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.function.Executable;
 
-import java.lang.reflect.Type;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -68,8 +66,7 @@ public final class OperationContractTest extends TestCreationBase {
 
             for (int i = 0; i < compare.size(); i++) {
                 String operations = contract.getOperations(ctx, input.get(i*6), input.get(i*6+1), input.get(i*6+2), input.get(i*6+3), input.get(i*6+4), input.get(i*6+5));
-                Type listType = new TypeToken<ArrayList<OperationData>>() {}.getType();
-                List<OperationData> operationDataList = GsonWrapper.fromJson(operations, listType);
+                List<OperationData> operationDataList = Arrays.asList(GsonWrapper.fromJson(operations, OperationData[].class).clone());
                 List<String> operationIds = operationDataList.stream().map(OperationData::getOperationId).collect(Collectors.toList());
                 assertThat(GsonWrapper.toJson(operationIds)).isEqualTo(compare.get(i));
             }
@@ -164,10 +161,10 @@ public final class OperationContractTest extends TestCreationBase {
             matriculationContract.addMatriculationData(ctx, input.get(0));
             String operationId = GsonWrapper.fromJson(operationJson, OperationData.class).getOperationId();
             stub.setFunction("UC4.OperationData:approveTransaction");
-            Type listType = new TypeToken<ArrayList<OperationData>>() {
 
-            }.getType();
-            List<OperationData> operations = GsonWrapper.fromJson(contract.getOperations(ctx, GsonWrapper.toJson(Collections.singletonList(operationId)), "", "", "", "", ""), listType);
+            String getOperationsResult = contract.getOperations(ctx, GsonWrapper.toJson(Collections.singletonList(operationId)), "", "", "", "", "");
+            List<OperationData> operations = Arrays.asList(GsonWrapper.fromJson
+                    (getOperationsResult, OperationData[].class).clone());
             OperationData operation = operations.get(0);
             OperationDataState expectedState = GsonWrapper.fromJson(compare.get(0), OperationDataState.class);
             assertThat(operation.getState()).isEqualTo(expectedState);

--- a/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/TestCreationBase.java
+++ b/UC4-chaincode/src/test/java/de/upb/cs/uc4/chaincode/TestCreationBase.java
@@ -1,18 +1,19 @@
 package de.upb.cs.uc4.chaincode;
 
 
-import com.google.gson.reflect.TypeToken;
 import de.upb.cs.uc4.chaincode.model.JsonIOTest;
 import de.upb.cs.uc4.chaincode.helper.GsonWrapper;
 import de.upb.cs.uc4.chaincode.util.TestUtil;
+import org.assertj.core.util.Files;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
-import java.lang.reflect.Type;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,21 +30,14 @@ public abstract class TestCreationBase {
         File[] testConfigs = dir.listFiles();
 
         List<JsonIOTest> testConfig;
-        Type type = new TypeToken<List<JsonIOTest>>() {
-        }.getType();
-        ArrayList<DynamicTest> tests = new ArrayList<>();
+        List<DynamicTest> tests = new ArrayList<>();
 
         if (testConfigs == null) {
             throw new RuntimeException("No test configurations found.");
         }
 
         for (File file : testConfigs) {
-            try {
-                testConfig = GsonWrapper.fromJson(new FileReader(file.getPath()), type);
-            } catch (FileNotFoundException e) {
-                e.printStackTrace();
-                return null;
-            }
+            testConfig = Arrays.asList(GsonWrapper.fromJson(Files.contentOf(file, Charset.defaultCharset()), JsonIOTest[].class));
 
             for (JsonIOTest test : testConfig) {
                 test.setIds(test.getIds().stream().map(TestUtil::wrapEnrollmentId).collect(Collectors.toList()));


### PR DESCRIPTION
### Reason for this PR
- typeTokens make the code hard to understand

### Changes in this PR
- replace TypeToken with Array.class
- replace ArrayList with List as least restrictive
- remove obsolete reader support from GsonWrapper
